### PR TITLE
chore: paymaster support fixes for protocols

### DIFF
--- a/.changeset/late-clowns-add.md
+++ b/.changeset/late-clowns-add.md
@@ -1,0 +1,18 @@
+---
+'@mycelium-sdk/core': major
+---
+
+## What was changed?
+
+1. Added paymaster to ProxyProtocol to use with DeFi opportunities with Mycelium Cloud
+2. Updated tests for ProxyProtocol
+3. Added Paymaster support for DefaultSmartWallet
+4. Updated tests for DefaultSmartWallet.ts
+
+## Why was changed/added?
+
+1. Support usage of paymaster with DeFi opportunities from Mycelium Cloud
+
+## How to use the change?
+
+Pass the paymaster token to earn() and withdraw() methods of a wallet

--- a/.changeset/late-clowns-add.md
+++ b/.changeset/late-clowns-add.md
@@ -4,17 +4,17 @@
 
 ## What was changed?
 
-1. Added paymaster to ProxyProtocol to use with DeFi opportunities with Mycelium Cloud
-2. Updated tests for ProxyProtocol
-3. Added Paymaster support for DefaultSmartWallet
-4. Updated tests for DefaultSmartWallet.ts
-5. Added paymaster to SparkProtocol to use with Spark vaults
-6. Updated SparkProtocol tests
+- Added paymaster to ProxyProtocol to use with DeFi opportunities with Mycelium Cloud
+- Updated tests for ProxyProtocol
+- Added Paymaster support for DefaultSmartWallet
+- Updated tests for DefaultSmartWallet.ts
+- Added paymaster to SparkProtocol to use with Spark vaults
+- Updated SparkProtocol tests
 
 ## Why was changed/added?
 
-1. Support usage of paymaster with DeFi opportunities from Mycelium Cloud
-2. Supported usage of paymaster with DeFi opportunities with core SDK without Mycelium Cloud
+- Support usage of paymaster with DeFi opportunities from Mycelium Cloud
+- Supported usage of paymaster with DeFi opportunities with core SDK without Mycelium Cloud
 
 ## How to use the change?
 

--- a/.changeset/late-clowns-add.md
+++ b/.changeset/late-clowns-add.md
@@ -8,11 +8,15 @@
 2. Updated tests for ProxyProtocol
 3. Added Paymaster support for DefaultSmartWallet
 4. Updated tests for DefaultSmartWallet.ts
+5. Added paymaster to SparkProtocol to use with Spark vaults
+6. Updated SparkProtocol tests
 
 ## Why was changed/added?
 
 1. Support usage of paymaster with DeFi opportunities from Mycelium Cloud
+2. Supported usage of paymaster with DeFi opportunities with core SDK without Mycelium Cloud
 
 ## How to use the change?
 
-Pass the paymaster token to earn() and withdraw() methods of a wallet
+- Pass the paymaster token to earn() and withdraw() methods of a wallet
+- Pass the paymaster token to send() and sendBatch() methods of a wallet

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,5 +6,5 @@
     "@mycelium-sdk/cli": "1.0.1",
     "@mycelium-sdk/core": "1.0.0"
   },
-  "changesets": ["early-parks-walk", "five-pugs-make"]
+  "changesets": ["early-parks-walk", "five-pugs-make", "late-clowns-add"]
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @mycelium-sdk/cli
 
+## 1.0.2-alpha.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @mycelium-sdk/core@2.0.0-alpha.1
+
 ## 1.0.2-alpha.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycelium-sdk/cli",
-  "version": "1.0.2-alpha.0",
+  "version": "1.0.2-alpha.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -352,7 +352,9 @@ export class CLI {
     }
 
     logState('Depositing to vault...');
-    const result = await this.wallet.earn(selectedVault.vaultInfo, amountToDeposit);
+    const result = await this.wallet.earn(selectedVault.vaultInfo, amountToDeposit, {
+      paymasterToken: USDC_TOKEN_ADDRESS,
+    });
     logResult(`Deposit completed: ${result.hash}`);
   }
 
@@ -408,7 +410,9 @@ export class CLI {
     }
 
     logState('Withdrawing from vault...');
-    const result = await this.wallet.withdraw(selectedVault.vaultInfo, amountToWithdraw);
+    const result = await this.wallet.withdraw(selectedVault.vaultInfo, amountToWithdraw, {
+      paymasterToken: USDC_TOKEN_ADDRESS,
+    });
     logResult('Withdraw completed:', result.hash);
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -397,7 +397,7 @@ export class CLI {
     const currentVaultBalance = selectedVault.currentBalance;
 
     logState(
-      `Current vault balance: ${currentVaultBalance.actualCurrentBalance ?? currentVaultBalance}`,
+      `Current vault balance: ${currentVaultBalance.actualCurrentBalance || currentVaultBalance}`,
     );
     const amountToWithdraw = await this.ask(
       `Enter the amount to withdraw (hit "enter" to withdraw all balance): `,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -396,7 +396,9 @@ export class CLI {
 
     const currentVaultBalance = selectedVault.currentBalance;
 
-    logState(`Current vault balance: ${currentVaultBalance.actualCurrentBalance}`);
+    logState(
+      `Current vault balance: ${currentVaultBalance.actualCurrentBalance || currentVaultBalance}`,
+    );
     const amountToWithdraw = await this.ask(
       `Enter the amount to withdraw (hit "enter" to withdraw all balance): `,
     );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -397,7 +397,7 @@ export class CLI {
     const currentVaultBalance = selectedVault.currentBalance;
 
     logState(
-      `Current vault balance: ${currentVaultBalance.actualCurrentBalance || currentVaultBalance}`,
+      `Current vault balance: ${currentVaultBalance.actualCurrentBalance ?? currentVaultBalance}`,
     );
     const amountToWithdraw = await this.ask(
       `Enter the amount to withdraw (hit "enter" to withdraw all balance): `,

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @mycelium-sdk/core
 
+## 2.0.0-alpha.1
+
+### Major Changes
+
+- ## What was changed?
+  1. Added paymaster to ProxyProtocol to use with DeFi opportunities with Mycelium Cloud
+  2. Updated tests for ProxyProtocol
+  3. Added Paymaster support for DefaultSmartWallet
+  4. Updated tests for DefaultSmartWallet.ts
+
+  ## Why was changed/added?
+  1. Support usage of paymaster with DeFi opportunities from Mycelium Cloud
+
+  ## How to use the change?
+
+  Pass the paymaster token to earn() and withdraw() methods of a wallet
+
 ## 2.0.0-alpha.0
 
 ### Major Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycelium-sdk/core",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "type": "module",
   "private": false,
   "publishConfig": {

--- a/packages/sdk/src/constants/paymaster.ts
+++ b/packages/sdk/src/constants/paymaster.ts
@@ -3,7 +3,7 @@
 export const ERC20_PAYMASTER_ADDRESS = '0x6666666666667849c56f2850848ce1c4da65c68b';
 
 // Percentage of balance to reserve for gas payment for tokens with high decimals (>8)
-export const GAS_RESERVE_PERCENTAGE = 1;
+export const GAS_RESERVE_PERCENTAGE = '1';
 
 // Minimum gas reserve amount in token units for tokens with low decimals (<8)
-export const GAS_RESERVE_MINIMUM = 0.01;
+export const GAS_RESERVE_MINIMUM = '0.01';

--- a/packages/sdk/src/constants/paymaster.ts
+++ b/packages/sdk/src/constants/paymaster.ts
@@ -1,3 +1,9 @@
 // Hardcoded ERC20 paymaster address as getTokenQuotes() of permissionless.js library doesn't return a correct paymaster address for 0.7 entry points version
 // The address is valid for all chain where the Pimlico paymaster is deployed
 export const ERC20_PAYMASTER_ADDRESS = '0x6666666666667849c56f2850848ce1c4da65c68b';
+
+// Percentage of balance to reserve for gas payment for tokens with high decimals (>8)
+export const GAS_RESERVE_PERCENTAGE = 1;
+
+// Minimum gas reserve amount in token units for tokens with low decimals (<8)
+export const GAS_RESERVE_MINIMUM = 0.01;

--- a/packages/sdk/src/protocols/base/BaseProtocol.ts
+++ b/packages/sdk/src/protocols/base/BaseProtocol.ts
@@ -6,8 +6,11 @@ import {
   createWalletClient,
   http,
   parseGwei,
+  parseUnits,
+  formatUnits,
   type PublicClient,
 } from 'viem';
+import { GAS_RESERVE_MINIMUM, GAS_RESERVE_PERCENTAGE } from '@/constants/paymaster';
 import type { SupportedChainId } from '@/constants/chains';
 import type { SmartWallet } from '@/wallet/base/wallets/SmartWallet';
 import type {
@@ -94,7 +97,7 @@ export abstract class BaseProtocol {
    */
   abstract withdraw(
     vaultInfo: VaultInfo,
-    amountInShares: string,
+    amount: string,
     smartWallet: SmartWallet,
     options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult>;
@@ -168,5 +171,95 @@ export abstract class BaseProtocol {
       functionName: 'allowance',
       args: [walletAddress, spenderAddress],
     });
+  }
+
+  /**
+   * Validate gas reserve balance for operations using paymaster
+   * Ensures sufficient balance remains for gas payment when using paymaster with the same token
+   * @param tokenAddress Token address to check balance for
+   * @param walletAddress Wallet address to check
+   * @param tokenDecimals Number of decimals for the token
+   * @param operationAmount Optional: Amount for deposit operation (in token units). If provided, validates deposit; otherwise validates withdraw
+   * @throws Error if balance is insufficient for gas payment or operation
+   */
+  protected async validateGasReserve(
+    tokenAddress: Address,
+    walletAddress: Address,
+    tokenDecimals: number,
+    operationAmount?: bigint,
+  ): Promise<void> {
+    this.ensureInitialized();
+    const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
+    const balance = await publicClient.readContract({
+      address: tokenAddress,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [walletAddress],
+    });
+
+    const gasReserve = this.calculateGasReserve(balance, tokenDecimals);
+
+    if (operationAmount !== undefined) {
+      // Check if operation amount exceeds available balance after gas reserve
+      const maxDepositAmount = balance > gasReserve ? balance - gasReserve : 0n;
+
+      if (operationAmount > maxDepositAmount) {
+        const maxDepositFormatted = formatUnits(maxDepositAmount, tokenDecimals);
+        throw new Error(
+          `Insufficient balance. Must reserve tokens for gas payment. Max deposit: ${maxDepositFormatted}`,
+        );
+      }
+    } else {
+      // Check if balance meets minimum gas reserve requirement
+      const minRequiredBalance = gasReserve;
+
+      if (balance < minRequiredBalance) {
+        const minRequiredFormatted = formatUnits(minRequiredBalance, tokenDecimals);
+        throw new Error(
+          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted} tokens to pay for gas before withdrawal.`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Calculate gas reserve amount based on balance and token decimals
+   * Uses a more sophisticated calculation that considers token decimal places:
+   * - For tokens with low decimals (≤6): Uses a fixed minimum amount configured via
+   *   GAS_RESERVE_MINIMUM (e.g., 0.01 tokens), with at least 1 unit reserved
+   * - For tokens with higher decimals (>6): Uses GAS_RESERVE_PERCENTAGE% of balance
+   *   with a minimum of 1 unit
+   * @param balance Current token balance
+   * @param tokenDecimals Number of decimals for the token
+   * @returns Gas reserve amount in token units
+   */
+  protected calculateGasReserve(balance: bigint, tokenDecimals: number): bigint {
+    // For tokens with low decimals (e.g., WBTC with 8 decimals), use a fixed minimum
+    // This ensures sufficient gas coverage for high-value tokens
+    if (tokenDecimals <= 6) {
+      // Reserve 0.001 tokens (or 1 unit if that's larger)
+      const fixedReserve = parseUnits(GAS_RESERVE_MINIMUM, tokenDecimals);
+      const oneUnit = 1n;
+      return fixedReserve > oneUnit ? fixedReserve : oneUnit;
+    }
+
+    // For tokens with high decimals, use percentage-based approach
+    // Reserve 1% of balance with a minimum of 1 unit
+    const percentageReserve = (balance * BigInt(GAS_RESERVE_PERCENTAGE)) / 100n;
+    const oneUnit = 1n;
+    return percentageReserve > 0n ? percentageReserve : oneUnit;
+  }
+
+  /**
+   * Get the selected chain ID, ensuring it has been initialized
+   * @returns The selected chain ID
+   * @throws Error if `init()` has not been called or chain ID is not set
+   */
+  protected getSelectedChainId(): SupportedChainId {
+    this.ensureInitialized();
+    if (this.selectedChainId === undefined) {
+      throw new Error('Protocol chain ID not set. Ensure init() was called successfully.');
+    }
+    return this.selectedChainId;
   }
 }

--- a/packages/sdk/src/protocols/base/BaseProtocol.ts
+++ b/packages/sdk/src/protocols/base/BaseProtocol.ts
@@ -226,26 +226,26 @@ export abstract class BaseProtocol {
   /**
    * Calculate gas reserve amount based on balance and token decimals
    * Uses a more sophisticated calculation that considers token decimal places:
-   * - For tokens with low decimals (≤6): Uses a fixed minimum amount configured via
-   *   GAS_RESERVE_MINIMUM (e.g., 0.01 tokens), with at least 1 unit reserved
-   * - For tokens with higher decimals (>6): Uses GAS_RESERVE_PERCENTAGE% of balance
+   * - For tokens with low decimals (≤6): uses a fixed minimum amount configured via
+   *   GAS_RESERVE_MINIMUM (e.g., currently 0.01 tokens), with at least 1 unit reserved
+   * - For tokens with higher decimals (>6): uses GAS_RESERVE_PERCENTAGE% of the balance,
    *   with a minimum of 1 unit
    * @param balance Current token balance
    * @param tokenDecimals Number of decimals for the token
    * @returns Gas reserve amount in token units
    */
   protected calculateGasReserve(balance: bigint, tokenDecimals: number): bigint {
-    // For tokens with low decimals (e.g., WBTC with 8 decimals), use a fixed minimum
-    // This ensures sufficient gas coverage for high-value tokens
+    // For tokens with low decimals (e.g., 6-decimal tokens like USDC), use a fixed minimum
+    // This ensures sufficient gas coverage for high-value or low-decimal tokens
     if (tokenDecimals <= 6) {
-      // Reserve 0.001 tokens (or 1 unit if that's larger)
+      // Reserve GAS_RESERVE_MINIMUM tokens (e.g., 0.01) or 1 unit if that's larger
       const fixedReserve = parseUnits(GAS_RESERVE_MINIMUM, tokenDecimals);
       const oneUnit = 1n;
       return fixedReserve > oneUnit ? fixedReserve : oneUnit;
     }
 
-    // For tokens with high decimals, use percentage-based approach
-    // Reserve 1% of balance with a minimum of 1 unit
+    // For tokens with higher decimals, use a percentage-based approach
+    // Reserve GAS_RESERVE_PERCENTAGE% of the balance with a minimum of 1 unit
     const percentageReserve = (balance * BigInt(GAS_RESERVE_PERCENTAGE)) / 100n;
     const oneUnit = 1n;
     return percentageReserve > 0n ? percentageReserve : oneUnit;

--- a/packages/sdk/src/protocols/base/BaseProtocol.ts
+++ b/packages/sdk/src/protocols/base/BaseProtocol.ts
@@ -82,6 +82,7 @@ export abstract class BaseProtocol {
     vaultInfo: VaultInfo,
     amount: string,
     smartWallet: SmartWallet,
+    options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult>;
 
   /**
@@ -95,6 +96,7 @@ export abstract class BaseProtocol {
     vaultInfo: VaultInfo,
     amountInShares: string,
     smartWallet: SmartWallet,
+    options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult>;
 
   /**

--- a/packages/sdk/src/protocols/base/BaseProtocol.ts
+++ b/packages/sdk/src/protocols/base/BaseProtocol.ts
@@ -97,7 +97,7 @@ export abstract class BaseProtocol {
    */
   abstract withdraw(
     vaultInfo: VaultInfo,
-    amount: string,
+    amount?: string,
     smartWallet: SmartWallet,
     options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult>;

--- a/packages/sdk/src/protocols/base/BaseProtocol.ts
+++ b/packages/sdk/src/protocols/base/BaseProtocol.ts
@@ -189,7 +189,8 @@ export abstract class BaseProtocol {
     operationAmount?: bigint,
   ): Promise<void> {
     this.ensureInitialized();
-    const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
+    const chainId = this.getSelectedChainId();
+    const publicClient = this.chainManager!.getPublicClient(chainId);
     const balance = await publicClient.readContract({
       address: tokenAddress,
       abi: erc20Abi,

--- a/packages/sdk/src/protocols/base/BaseProtocol.ts
+++ b/packages/sdk/src/protocols/base/BaseProtocol.ts
@@ -97,8 +97,8 @@ export abstract class BaseProtocol {
    */
   abstract withdraw(
     vaultInfo: VaultInfo,
-    amount?: string,
     smartWallet: SmartWallet,
+    amount?: string,
     options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult>;
 
@@ -228,8 +228,9 @@ export abstract class BaseProtocol {
    * Uses a more sophisticated calculation that considers token decimal places:
    * - For tokens with low decimals (≤6): uses a fixed minimum amount configured via
    *   GAS_RESERVE_MINIMUM (e.g., currently 0.01 tokens), with at least 1 unit reserved
-   * - For tokens with higher decimals (>6): uses GAS_RESERVE_PERCENTAGE% of the balance,
-   *   with a minimum of 1 unit
+   * - For tokens with more than 6 decimals: uses the maximum of GAS_RESERVE_PERCENTAGE%
+   *   of the balance and a fixed minimum (GAS_RESERVE_MINIMUM), ensuring a balance-independent
+   *   minimum for withdraw validation
    * @param balance Current token balance
    * @param tokenDecimals Number of decimals for the token
    * @returns Gas reserve amount in token units
@@ -244,11 +245,13 @@ export abstract class BaseProtocol {
       return fixedReserve > oneUnit ? fixedReserve : oneUnit;
     }
 
-    // For tokens with higher decimals, use a percentage-based approach
-    // Reserve GAS_RESERVE_PERCENTAGE% of the balance with a minimum of 1 unit
+    // For tokens with more than 6 decimals, use the maximum of percentage-based and fixed minimum
+    // This ensures withdraw validation has a meaningful balance-independent minimum
     const percentageReserve = (balance * BigInt(GAS_RESERVE_PERCENTAGE)) / 100n;
-    const oneUnit = 1n;
-    return percentageReserve > 0n ? percentageReserve : oneUnit;
+    const fixedMinimum = parseUnits(GAS_RESERVE_MINIMUM, tokenDecimals);
+
+    // Return the maximum of the two to ensure adequate reserve for gas payment
+    return percentageReserve > 0n ? percentageReserve : fixedMinimum;
   }
 
   /**

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
@@ -405,7 +405,7 @@ describe('ProxyProtocol integration tests', () => {
 
       (smartWallet.send as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
-      const result = await proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet);
+      const result = await proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500');
 
       expect(apiClient.sendRequest).toHaveBeenCalledWith('withdraw', undefined, 'spark', {
         vaultInfo: mockVaultInfo,
@@ -444,7 +444,7 @@ describe('ProxyProtocol integration tests', () => {
 
       (smartWallet.send as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
-      const result = await proxyProtocol.withdraw(mockVaultInfo, '', smartWallet);
+      const result = await proxyProtocol.withdraw(mockVaultInfo, smartWallet);
 
       expect(apiClient.sendRequest).toHaveBeenCalledWith('withdraw', undefined, 'spark', {
         vaultInfo: mockVaultInfo,
@@ -458,7 +458,7 @@ describe('ProxyProtocol integration tests', () => {
     it('should throw error when no earning balances found', async () => {
       vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(null);
 
-      await expect(proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet)).rejects.toThrow(
+      await expect(proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500')).rejects.toThrow(
         'No earning balances found',
       );
     });
@@ -473,7 +473,7 @@ describe('ProxyProtocol integration tests', () => {
 
       vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
 
-      await expect(proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet)).rejects.toThrow(
+      await expect(proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500')).rejects.toThrow(
         'No earning balance found',
       );
     });
@@ -493,7 +493,7 @@ describe('ProxyProtocol integration tests', () => {
         error: 'API error',
       });
 
-      await expect(proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet)).rejects.toThrow(
+      await expect(proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500')).rejects.toThrow(
         'API error',
       );
     });
@@ -524,7 +524,7 @@ describe('ProxyProtocol integration tests', () => {
 
       (smartWallet.send as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
-      await proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet);
+      await proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500');
 
       expect(apiClient.sendRequest).toHaveBeenCalledWith(
         'log',
@@ -571,7 +571,7 @@ describe('ProxyProtocol integration tests', () => {
 
       (smartWallet.send as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
-      const result = await proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet, {
+      const result = await proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500', {
         paymasterToken,
       });
 
@@ -606,7 +606,7 @@ describe('ProxyProtocol integration tests', () => {
       );
 
       await expect(
-        proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet, { paymasterToken }),
+        proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500', { paymasterToken }),
       ).rejects.toThrow('Insufficient wallet balance for gas payment');
     });
   });

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
@@ -10,11 +10,8 @@ import type {
   VaultInfo,
   VaultBalance,
 } from '@mycelium-sdk/core/types/protocols/general';
-import type {
-  ProxyVaults,
-  ProxyBalance,
-  OperationCallDataType,
-} from '@mycelium-sdk/core/types/protocols/proxy';
+import type { ProxyVaults, ProxyBalance } from '@mycelium-sdk/core/types/protocols/proxy';
+import type { TransactionData } from '@mycelium-sdk/core/types/transaction';
 import { encodeFunctionData, erc20Abi, parseUnits, type Address, type Hash } from 'viem';
 
 // Mock viem functions
@@ -178,7 +175,7 @@ describe('ProxyProtocol integration tests', () => {
         BigInt('2000000000'), // Allowance is greater than deposit amount
       );
 
-      const mockOperationData: OperationCallDataType = {
+      const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
         data: '0x1234' as `0x${string}`,
       };
@@ -220,7 +217,7 @@ describe('ProxyProtocol integration tests', () => {
       const mockApproveData = '0xhash123' as `0x${string}`;
       vi.mocked(encodeFunctionData).mockReturnValue(mockApproveData);
 
-      const mockOperationData: OperationCallDataType = {
+      const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
         data: '0x1234' as `0x${string}`,
       };
@@ -289,7 +286,7 @@ describe('ProxyProtocol integration tests', () => {
         BigInt('2000000000'),
       );
 
-      const mockOperationData: OperationCallDataType = {
+      const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
         data: '0x1234' as `0x${string}`,
       };
@@ -318,6 +315,63 @@ describe('ProxyProtocol integration tests', () => {
         }),
       );
     });
+
+    it('should deposit with paymaster token when paymaster token equals deposit token', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+
+      // Mock balance check (for gas reserve) and allowance check
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(BigInt('2000000000'))
+        .mockResolvedValueOnce(BigInt('2000000000'));
+
+      const mockOperationData: TransactionData = {
+        to: mockVaultInfo.vaultAddress,
+        data: '0x1234' as `0x${string}`,
+      };
+
+      (apiClient.sendRequest as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          success: true,
+          data: mockOperationData,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+        });
+
+      (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash123' as Hash);
+
+      const result = await proxyProtocol.deposit(mockVaultInfo, '1000', smartWallet, {
+        paymasterToken,
+      });
+
+      expect(mockPublicClient.readContract).toHaveBeenCalledWith({
+        address: mockVaultInfo.tokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [expect.any(String)],
+      });
+
+      expect(smartWallet.sendBatch).toHaveBeenCalledWith([mockOperationData], 8453, {
+        paymasterToken,
+      });
+      expect(result.success).toBe(true);
+      expect(result.hash).toBe('0xhash123');
+    });
+
+    it('should throw error when deposit amount exceeds balance minus gas reserve', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+
+      // Mock balance that's too low for gas reserve
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
+        BigInt('500000000'),
+      );
+
+      await expect(
+        proxyProtocol.deposit(mockVaultInfo, '1000', smartWallet, { paymasterToken }),
+      ).rejects.toThrow('Insufficient balance. Must reserve tokens for gas payment.');
+    });
   });
 
   describe('withdraw', () => {
@@ -335,7 +389,7 @@ describe('ProxyProtocol integration tests', () => {
 
       vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
 
-      const mockOperationData: OperationCallDataType = {
+      const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
         data: '0xhash123' as `0x${string}`,
       };
@@ -374,7 +428,7 @@ describe('ProxyProtocol integration tests', () => {
 
       vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
 
-      const mockOperationData: OperationCallDataType = {
+      const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
         data: '0xhash123' as `0x${string}`,
       };
@@ -454,7 +508,7 @@ describe('ProxyProtocol integration tests', () => {
 
       vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
 
-      const mockOperationData: OperationCallDataType = {
+      const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
         data: '0xhash123' as `0x${string}`,
       };
@@ -482,6 +536,78 @@ describe('ProxyProtocol integration tests', () => {
           transactionHash: '0xhash456',
         }),
       );
+    });
+
+    it('should withdraw with paymaster token when paymaster token equals withdraw token', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+      const mockEarningBalances: VaultBalance[] = [
+        {
+          vaultInfo: mockVaultInfo,
+          balance: mockProxyBalance,
+        },
+      ];
+
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+
+      // Mock balance check for gas reserve
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
+        BigInt('2000000000'),
+      );
+
+      const mockOperationData: TransactionData = {
+        to: mockVaultInfo.vaultAddress,
+        data: '0xhash123' as `0x${string}`,
+      };
+
+      (apiClient.sendRequest as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          success: true,
+          data: mockOperationData,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+        });
+
+      (smartWallet.send as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
+
+      const result = await proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet, {
+        paymasterToken,
+      });
+
+      // Verify balance check was performed
+      expect(mockPublicClient.readContract).toHaveBeenCalledWith({
+        address: mockVaultInfo.tokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [expect.any(String)],
+      });
+
+      expect(smartWallet.send).toHaveBeenCalledWith(mockOperationData, 8453, { paymasterToken });
+      expect(result.success).toBe(true);
+      expect(result.hash).toBe('0xhash456');
+    });
+
+    it('should throw error when wallet balance is insufficient for gas payment', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+      const mockEarningBalances: VaultBalance[] = [
+        {
+          vaultInfo: mockVaultInfo,
+          balance: mockProxyBalance,
+        },
+      ];
+
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+
+      // Mock balance that's too low for gas reserve
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
+        BigInt('0'),
+      );
+
+      await expect(
+        proxyProtocol.withdraw(mockVaultInfo, '500', smartWallet, { paymasterToken }),
+      ).rejects.toThrow('Insufficient wallet balance for gas payment');
     });
   });
 

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
@@ -203,7 +203,7 @@ describe('ProxyProtocol integration tests', () => {
 
       expect(result.success).toBe(true);
       expect(result.hash).toBe('0xhash123');
-      expect(smartWallet.sendBatch).toHaveBeenCalledWith([mockOperationData], 8453);
+      expect(smartWallet.sendBatch).toHaveBeenCalledWith([mockOperationData], 8453, undefined);
       expect(apiClient.sendRequest).toHaveBeenCalledWith('deposit', undefined, 'spark', {
         vaultInfo: mockVaultInfo,
         amount: '1000',
@@ -253,6 +253,7 @@ describe('ProxyProtocol integration tests', () => {
           mockOperationData,
         ],
         8453,
+        undefined,
       );
 
       expect(result.success).toBe(true);
@@ -355,10 +356,10 @@ describe('ProxyProtocol integration tests', () => {
       expect(apiClient.sendRequest).toHaveBeenCalledWith('withdraw', undefined, 'spark', {
         vaultInfo: mockVaultInfo,
         amount: '500',
-        chainId: '8453',
+        chainId: 8453,
       });
 
-      expect(smartWallet.send).toHaveBeenCalledWith(mockOperationData, 8453);
+      expect(smartWallet.send).toHaveBeenCalledWith(mockOperationData, 8453, undefined);
       expect(result.success).toBe(true);
       expect(result.hash).toBe('0xhash456');
     });
@@ -394,7 +395,7 @@ describe('ProxyProtocol integration tests', () => {
       expect(apiClient.sendRequest).toHaveBeenCalledWith('withdraw', undefined, 'spark', {
         vaultInfo: mockVaultInfo,
         amount: mockProxyBalance.currentBalance,
-        chainId: '8453',
+        chainId: 8453,
       });
 
       expect(result.success).toBe(true);

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
@@ -7,10 +7,11 @@ import type {
   Vaults,
   VaultTxnResult,
 } from '@/types/protocols/general';
-import type { OperationCallDataType, ProxyBalance, ProxyVaults } from '@/types/protocols/proxy';
+import type { ProxyBalance, ProxyVaults } from '@/types/protocols/proxy';
 import { encodeFunctionData, erc20Abi, parseUnits, type Address, type Hash } from 'viem';
 import type { SmartWallet } from '@/public/types';
 import type { ApiClient } from '@/tools/ApiClient';
+import type { TransactionData } from '@/types/transaction';
 
 /**
  * Proxy protocol implementation that communicates with the backend to find optimal vaults
@@ -45,7 +46,7 @@ export class ProxyProtocol extends BaseProtocol {
     this.chainManager = chainManager;
     this.selectedChainId = chainManager.getSupportedChain();
 
-    this.publicClient = chainManager.getPublicClient(this.selectedChainId!);
+    this.publicClient = chainManager.getPublicClient(this.getSelectedChainId());
 
     this.apiClient = apiClient;
 
@@ -101,7 +102,7 @@ export class ProxyProtocol extends BaseProtocol {
   ): Promise<Vaults> {
     const pathParams = {
       risk_level: this.protocolsSecurityConfig.riskLevel,
-      chain_id: this.selectedChainId!.toString(),
+      chain_id: this.getSelectedChainId().toString(),
       stable_vaults_limit: stableVaultsLimit.toString(),
       non_stable_vaults_limit: nonStableVaultsLimit.toString(),
     };
@@ -151,48 +152,35 @@ export class ProxyProtocol extends BaseProtocol {
   ): Promise<VaultTxnResult> {
     const currentAddress = await smartWallet.getAddress();
 
-    const operationsCallData = [];
+    const operationsCallData: TransactionData[] = [];
     const depositTokenDecimals = vaultInfo.tokenDecimals;
     const depositTokenAddress = vaultInfo.tokenAddress;
     const vaultAddress = vaultInfo.vaultAddress;
 
     const rawDepositAmount = parseUnits(amount, depositTokenDecimals);
 
-    // If paymaster token and deposit token are the same, reserve balance for gas
+    // If paymaster token and deposit token are the same, validate gas reserve balance
     if (
       options?.paymasterToken &&
       options.paymasterToken.toLowerCase() === depositTokenAddress.toLowerCase()
     ) {
-      this.ensureInitialized();
-      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
-      const balance = await publicClient.readContract({
-        address: depositTokenAddress,
-        abi: erc20Abi,
-        functionName: 'balanceOf',
-        args: [currentAddress],
-      });
-
-      // Reserve ~1% for gas payment (minimum 1 unit)
-      const gasReserve = balance / 100n > 0n ? balance / 100n : 1n;
-      const maxDepositAmount = balance > gasReserve ? balance - gasReserve : 0n;
-
-      if (rawDepositAmount > maxDepositAmount) {
-        const maxDepositFormatted = Number(maxDepositAmount) / 10 ** depositTokenDecimals;
-        throw new Error(
-          `Insufficient balance. Must reserve tokens for gas payment. Max deposit: ${maxDepositFormatted.toFixed(depositTokenDecimals)}`,
-        );
-      }
+      await this.validateGasReserve(
+        depositTokenAddress,
+        currentAddress,
+        depositTokenDecimals,
+        rawDepositAmount,
+      );
     }
 
     const allowance = await this.checkAllowance(
       depositTokenAddress,
       vaultAddress,
       currentAddress,
-      this.selectedChainId!,
+      this.getSelectedChainId(),
     );
 
     if (allowance < rawDepositAmount) {
-      const approveData = {
+      const approveData: TransactionData = {
         to: depositTokenAddress,
         data: encodeFunctionData({
           abi: erc20Abi,
@@ -215,7 +203,7 @@ export class ProxyProtocol extends BaseProtocol {
       {
         vaultInfo,
         amount: amount.toString(),
-        chainId: this.selectedChainId!.toString(),
+        chainId: this.getSelectedChainId().toString(),
       },
     );
 
@@ -223,11 +211,15 @@ export class ProxyProtocol extends BaseProtocol {
       throw new Error(apiResponse.error || 'Failed to receive deposit operations call data');
     }
 
-    const receivedOperationsCallData = apiResponse.data as unknown as OperationCallDataType;
+    const receivedOperationsCallData = apiResponse.data as unknown as TransactionData;
 
     operationsCallData.push(receivedOperationsCallData);
 
-    const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!, options);
+    const hash = await smartWallet.sendBatch(
+      operationsCallData,
+      this.getSelectedChainId(),
+      options,
+    );
 
     const operationStatus = hash ? 'completed' : ('failed' as 'completed' | 'failed');
 
@@ -235,7 +227,7 @@ export class ProxyProtocol extends BaseProtocol {
       currentAddress,
       hash,
       vaultInfo,
-      this.selectedChainId!,
+      this.getSelectedChainId(),
       amount,
       'deposit',
       operationStatus,
@@ -276,30 +268,12 @@ export class ProxyProtocol extends BaseProtocol {
 
     const amountToWithdraw = amount ? amount : balanceInfo.currentBalance;
 
+    // If paymaster token and withdraw token are the same, validate gas reserve balance
     if (
       options?.paymasterToken &&
       options.paymasterToken.toLowerCase() === tokenAddress.toLowerCase()
     ) {
-      this.ensureInitialized();
-      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
-      const walletBalance = await publicClient.readContract({
-        address: tokenAddress,
-        abi: erc20Abi,
-        functionName: 'balanceOf',
-        args: [currentAddress],
-      });
-
-      // Reserve ~1% for gas payment (minimum 1 unit)
-      // The wallet must have enough balance BEFORE withdrawal to pay for gas
-      const gasReserve = walletBalance / 100n > 0n ? walletBalance / 100n : 1n;
-      const minRequiredBalance = gasReserve;
-
-      if (walletBalance < minRequiredBalance) {
-        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** tokenDecimals;
-        throw new Error(
-          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(tokenDecimals)} tokens to pay for gas before withdrawal.`,
-        );
-      }
+      await this.validateGasReserve(tokenAddress, currentAddress, tokenDecimals);
     }
 
     const apiResponse = await this.apiClient.sendRequest(
@@ -309,7 +283,7 @@ export class ProxyProtocol extends BaseProtocol {
       {
         vaultInfo,
         amount: amountToWithdraw,
-        chainId: this.selectedChainId!,
+        chainId: this.getSelectedChainId(),
       },
     );
 
@@ -317,9 +291,13 @@ export class ProxyProtocol extends BaseProtocol {
       throw new Error(apiResponse.error || 'Failed to receive withdraw operations call data');
     }
 
-    const withdrawOperationCallData = apiResponse.data as unknown as OperationCallDataType;
+    const withdrawOperationCallData = apiResponse.data as unknown as TransactionData;
 
-    const hash = await smartWallet.send(withdrawOperationCallData, this.selectedChainId!, options);
+    const hash = await smartWallet.send(
+      withdrawOperationCallData,
+      this.getSelectedChainId(),
+      options,
+    );
 
     const operationStatus = hash ? 'completed' : ('failed' as 'completed' | 'failed');
 
@@ -327,7 +305,7 @@ export class ProxyProtocol extends BaseProtocol {
       currentAddress,
       hash,
       vaultInfo,
-      this.selectedChainId!,
+      this.getSelectedChainId(),
       amountToWithdraw,
       'withdrawal',
       operationStatus,
@@ -344,7 +322,7 @@ export class ProxyProtocol extends BaseProtocol {
    */
   async getBalances(walletAddress: Address, protocolId?: string): Promise<VaultBalance[]> {
     const pathParams = {
-      chain_id: this.selectedChainId!.toString(),
+      chain_id: this.getSelectedChainId().toString(),
       protocol_id: protocolId || '',
       userAddress: walletAddress,
     };

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
@@ -147,6 +147,7 @@ export class ProxyProtocol extends BaseProtocol {
     vaultInfo: VaultInfo,
     amount: string,
     smartWallet: SmartWallet,
+    options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult> {
     const currentAddress = await smartWallet.getAddress();
 
@@ -156,6 +157,32 @@ export class ProxyProtocol extends BaseProtocol {
     const vaultAddress = vaultInfo.vaultAddress;
 
     const rawDepositAmount = parseUnits(amount, depositTokenDecimals);
+
+    // If paymaster token and deposit token are the same, reserve balance for gas
+    if (
+      options?.paymasterToken &&
+      options.paymasterToken.toLowerCase() === depositTokenAddress.toLowerCase()
+    ) {
+      this.ensureInitialized();
+      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
+      const balance = await publicClient.readContract({
+        address: depositTokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [currentAddress],
+      });
+
+      // Reserve ~1% for gas payment (minimum 1 unit)
+      const gasReserve = balance / 100n > 0n ? balance / 100n : 1n;
+      const maxDepositAmount = balance > gasReserve ? balance - gasReserve : 0n;
+
+      if (rawDepositAmount > maxDepositAmount) {
+        const maxDepositFormatted = Number(maxDepositAmount) / 10 ** depositTokenDecimals;
+        throw new Error(
+          `Insufficient balance. Must reserve tokens for gas payment. Max deposit: ${maxDepositFormatted.toFixed(depositTokenDecimals)}`,
+        );
+      }
+    }
 
     const allowance = await this.checkAllowance(
       depositTokenAddress,
@@ -200,7 +227,7 @@ export class ProxyProtocol extends BaseProtocol {
 
     operationsCallData.push(receivedOperationsCallData);
 
-    const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!);
+    const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!, options);
 
     const operationStatus = hash ? 'completed' : ('failed' as 'completed' | 'failed');
 
@@ -228,6 +255,7 @@ export class ProxyProtocol extends BaseProtocol {
     vaultInfo: VaultInfo,
     amount: string,
     smartWallet: SmartWallet,
+    options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult> {
     const currentAddress = await smartWallet.getAddress();
 
@@ -246,6 +274,32 @@ export class ProxyProtocol extends BaseProtocol {
 
     const amountToWithdraw = amount ? amount : balanceInfo.currentBalance;
 
+    if (
+      options?.paymasterToken &&
+      options.paymasterToken.toLowerCase() === vaultInfo.tokenAddress.toLowerCase()
+    ) {
+      this.ensureInitialized();
+      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
+      const walletBalance = await publicClient.readContract({
+        address: vaultInfo.tokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [currentAddress],
+      });
+
+      // Reserve ~1% for gas payment (minimum 1 unit)
+      // The wallet must have enough balance BEFORE withdrawal to pay for gas
+      const gasReserve = walletBalance / 100n > 0n ? walletBalance / 100n : 1n;
+      const minRequiredBalance = gasReserve;
+
+      if (walletBalance < minRequiredBalance) {
+        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** vaultInfo.tokenDecimals;
+        throw new Error(
+          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(vaultInfo.tokenDecimals)} tokens to pay for gas before withdrawal.`,
+        );
+      }
+    }
+
     const apiResponse = await this.apiClient.sendRequest(
       'withdraw',
       undefined,
@@ -253,7 +307,7 @@ export class ProxyProtocol extends BaseProtocol {
       {
         vaultInfo,
         amount: amountToWithdraw,
-        chainId: this.selectedChainId!.toString(),
+        chainId: this.selectedChainId!,
       },
     );
 
@@ -263,7 +317,7 @@ export class ProxyProtocol extends BaseProtocol {
 
     const withdrawOperationCallData = apiResponse.data as unknown as OperationCallDataType;
 
-    const hash = await smartWallet.send(withdrawOperationCallData, this.selectedChainId!);
+    const hash = await smartWallet.send(withdrawOperationCallData, this.selectedChainId!, options);
 
     const operationStatus = hash ? 'completed' : ('failed' as 'completed' | 'failed');
 

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
@@ -258,8 +258,10 @@ export class ProxyProtocol extends BaseProtocol {
     options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult> {
     const currentAddress = await smartWallet.getAddress();
-
     const earningBalances = await smartWallet.getEarnBalances();
+
+    const tokenDecimals = vaultInfo.tokenDecimals;
+    const tokenAddress = vaultInfo.tokenAddress;
 
     if (!earningBalances) {
       throw new Error('No earning balances found');
@@ -276,12 +278,12 @@ export class ProxyProtocol extends BaseProtocol {
 
     if (
       options?.paymasterToken &&
-      options.paymasterToken.toLowerCase() === vaultInfo.tokenAddress.toLowerCase()
+      options.paymasterToken.toLowerCase() === tokenAddress.toLowerCase()
     ) {
       this.ensureInitialized();
       const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
       const walletBalance = await publicClient.readContract({
-        address: vaultInfo.tokenAddress,
+        address: tokenAddress,
         abi: erc20Abi,
         functionName: 'balanceOf',
         args: [currentAddress],
@@ -293,9 +295,9 @@ export class ProxyProtocol extends BaseProtocol {
       const minRequiredBalance = gasReserve;
 
       if (walletBalance < minRequiredBalance) {
-        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** vaultInfo.tokenDecimals;
+        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** tokenDecimals;
         throw new Error(
-          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(vaultInfo.tokenDecimals)} tokens to pay for gas before withdrawal.`,
+          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(tokenDecimals)} tokens to pay for gas before withdrawal.`,
         );
       }
     }

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
@@ -245,8 +245,8 @@ export class ProxyProtocol extends BaseProtocol {
    */
   async withdraw(
     vaultInfo: VaultInfo,
-    amount: string,
     smartWallet: SmartWallet,
+    amount?: string,
     options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult> {
     const currentAddress = await smartWallet.getAddress();

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
@@ -9,7 +9,6 @@ import {
   encodeFunctionData,
   erc20Abi,
   formatUnits,
-  maxUint256,
   parseUnits,
   type Address,
   type Hash,
@@ -306,17 +305,17 @@ describe('SparkProtocol integration tests', () => {
 
       await expect(
         uninitializedProtocol.withdraw(mockVaultInfo, undefined, smartWallet),
-      ).rejects.toThrow('Protocol must be initialized');
+      ).rejects.toThrow('Public client not initialized');
     });
 
     it('should withdraw with paymaster token when paymaster token equals withdraw token', async () => {
       const paymasterToken = mockVaultInfo.tokenAddress;
       const mockPublicClient = chainManager.getPublicClient(8453);
 
-      // Mock balance check for gas reserve and allowance check for sUSDC shares
-      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce(BigInt('2000000000'))
-        .mockResolvedValueOnce(BigInt('1000000000'));
+      // Mock balance check for gas reserve
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
+        BigInt('2000000000'),
+      );
 
       vi.mocked(parseUnits).mockReturnValue(BigInt('500000000'));
 
@@ -339,54 +338,6 @@ describe('SparkProtocol integration tests', () => {
 
       expect(smartWallet.sendBatch).toHaveBeenCalledWith(
         [
-          {
-            to: mockVaultInfo.vaultAddress,
-            data: mockWithdrawData,
-          },
-        ],
-        8453,
-        { paymasterToken },
-      );
-
-      expect(result.success).toBe(true);
-    });
-
-    it('should withdraw with paymaster token and include approval for sUSDC shares when needed', async () => {
-      const paymasterToken = mockVaultInfo.tokenAddress;
-      const mockPublicClient = chainManager.getPublicClient(8453);
-
-      // Mock balance check for gas reserve and no allowance for sUSDC shares
-      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce(BigInt('2000000000'))
-        .mockResolvedValueOnce(0n);
-
-      vi.mocked(parseUnits).mockReturnValue(BigInt('500000000'));
-
-      const mockApproveData = '0xhash123' as `0x${string}`;
-      const mockWithdrawData = '0xhash456' as `0x${string}`;
-
-      vi.mocked(encodeFunctionData)
-        .mockReturnValueOnce(mockApproveData)
-        .mockReturnValueOnce(mockWithdrawData);
-
-      (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash789' as Hash);
-
-      const result = await sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet, {
-        paymasterToken,
-      });
-
-      expect(encodeFunctionData).toHaveBeenCalledWith({
-        abi: erc20Abi,
-        functionName: 'approve',
-        args: [mockVaultInfo.vaultAddress, maxUint256],
-      });
-
-      expect(smartWallet.sendBatch).toHaveBeenCalledWith(
-        [
-          {
-            to: mockVaultInfo.vaultAddress,
-            data: mockApproveData,
-          },
           {
             to: mockVaultInfo.vaultAddress,
             data: mockWithdrawData,
@@ -496,7 +447,7 @@ describe('SparkProtocol integration tests', () => {
 
       await expect(
         uninitializedProtocol.withdraw(mockVaultInfo, undefined, smartWallet),
-      ).rejects.toThrow('Protocol must be initialized');
+      ).rejects.toThrow('Public client not initialized');
     });
   });
 

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
@@ -9,6 +9,7 @@ import {
   encodeFunctionData,
   erc20Abi,
   formatUnits,
+  maxUint256,
   parseUnits,
   type Address,
   type Hash,
@@ -186,6 +187,7 @@ describe('SparkProtocol integration tests', () => {
           },
         ],
         8453,
+        undefined,
       );
 
       expect(result.success).toBe(true);
@@ -233,9 +235,64 @@ describe('SparkProtocol integration tests', () => {
           },
         ],
         8453,
+        undefined,
       );
 
       expect(result.success).toBe(true);
+    });
+
+    it('should deposit with paymaster token when paymaster token equals deposit token', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+
+      // Mock balance check (for gas reserve) and allowance check
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(BigInt('2000000000'))
+        .mockResolvedValueOnce(BigInt('2000000000'));
+
+      const mockDepositData = '0xhash123' as `0x${string}`;
+      vi.mocked(encodeFunctionData).mockReturnValue(mockDepositData);
+
+      (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
+
+      const result = await sparkProtocol.deposit(mockVaultInfo, '1000', smartWallet, {
+        paymasterToken,
+      });
+
+      // Verify balance check was performed
+      expect(mockPublicClient.readContract).toHaveBeenCalledWith({
+        address: mockVaultInfo.tokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [expect.any(String)],
+      });
+
+      expect(smartWallet.sendBatch).toHaveBeenCalledWith(
+        [
+          {
+            to: mockVaultInfo.vaultAddress,
+            data: mockDepositData,
+          },
+        ],
+        8453,
+        { paymasterToken },
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should throw error when deposit amount exceeds balance minus gas reserve', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+
+      // Mock balance that's too low after gas reserve
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
+        BigInt('500000000'),
+      );
+
+      await expect(
+        sparkProtocol.deposit(mockVaultInfo, '1000', smartWallet, { paymasterToken }),
+      ).rejects.toThrow('Insufficient balance. Must reserve tokens for gas payment.');
     });
   });
 
@@ -244,13 +301,129 @@ describe('SparkProtocol integration tests', () => {
       await sparkProtocol.init(chainManager);
     });
 
-    it('should withdraw specified amount from vault', async () => {
-      vi.mocked(parseUnits).mockReturnValue(BigInt('500000000')); // 500 USDC
+    it('should throw error when public client is not initialized for max shares', async () => {
+      const uninitializedProtocol = new SparkProtocol();
+
+      await expect(
+        uninitializedProtocol.withdraw(mockVaultInfo, undefined, smartWallet),
+      ).rejects.toThrow('Protocol must be initialized');
+    });
+
+    it('should withdraw with paymaster token when paymaster token equals withdraw token', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+
+      // Mock balance check for gas reserve and allowance check for sUSDC shares
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(BigInt('2000000000'))
+        .mockResolvedValueOnce(BigInt('1000000000'));
+
+      vi.mocked(parseUnits).mockReturnValue(BigInt('500000000'));
 
       const mockWithdrawData = '0xhash123' as `0x${string}`;
       vi.mocked(encodeFunctionData).mockReturnValue(mockWithdrawData);
 
-      (smartWallet.send as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
+      (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
+
+      const result = await sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet, {
+        paymasterToken,
+      });
+
+      // Verify balance check was performed
+      expect(mockPublicClient.readContract).toHaveBeenCalledWith({
+        address: mockVaultInfo.tokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [expect.any(String)],
+      });
+
+      expect(smartWallet.sendBatch).toHaveBeenCalledWith(
+        [
+          {
+            to: mockVaultInfo.vaultAddress,
+            data: mockWithdrawData,
+          },
+        ],
+        8453,
+        { paymasterToken },
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should withdraw with paymaster token and include approval for sUSDC shares when needed', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+
+      // Mock balance check for gas reserve and no allowance for sUSDC shares
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(BigInt('2000000000'))
+        .mockResolvedValueOnce(0n);
+
+      vi.mocked(parseUnits).mockReturnValue(BigInt('500000000'));
+
+      const mockApproveData = '0xhash123' as `0x${string}`;
+      const mockWithdrawData = '0xhash456' as `0x${string}`;
+
+      vi.mocked(encodeFunctionData)
+        .mockReturnValueOnce(mockApproveData)
+        .mockReturnValueOnce(mockWithdrawData);
+
+      (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash789' as Hash);
+
+      const result = await sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet, {
+        paymasterToken,
+      });
+
+      expect(encodeFunctionData).toHaveBeenCalledWith({
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [mockVaultInfo.vaultAddress, maxUint256],
+      });
+
+      expect(smartWallet.sendBatch).toHaveBeenCalledWith(
+        [
+          {
+            to: mockVaultInfo.vaultAddress,
+            data: mockApproveData,
+          },
+          {
+            to: mockVaultInfo.vaultAddress,
+            data: mockWithdrawData,
+          },
+        ],
+        8453,
+        { paymasterToken },
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should throw error when wallet balance is insufficient for gas payment', async () => {
+      const paymasterToken = mockVaultInfo.tokenAddress;
+      const mockPublicClient = chainManager.getPublicClient(8453);
+
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
+        BigInt('0'),
+      );
+
+      await expect(
+        sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet, { paymasterToken }),
+      ).rejects.toThrow('Insufficient wallet balance for gas payment');
+    });
+
+    it('should withdraw specified amount from vault', async () => {
+      const mockPublicClient = chainManager.getPublicClient(8453);
+      vi.mocked(parseUnits).mockReturnValue(BigInt('500000000'));
+
+      vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
+        BigInt('1000000000'),
+      );
+
+      const mockWithdrawData = '0xhash123' as `0x${string}`;
+      vi.mocked(encodeFunctionData).mockReturnValue(mockWithdrawData);
+
+      (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
       const result = await sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet);
 
@@ -261,12 +434,15 @@ describe('SparkProtocol integration tests', () => {
         args: [BigInt('500000000'), expect.any(String), expect.any(String)],
       });
 
-      expect(smartWallet.send).toHaveBeenCalledWith(
-        {
-          to: mockVaultInfo.vaultAddress,
-          data: mockWithdrawData,
-        },
+      expect(smartWallet.sendBatch).toHaveBeenCalledWith(
+        [
+          {
+            to: mockVaultInfo.vaultAddress,
+            data: mockWithdrawData,
+          },
+        ],
         8453,
+        undefined,
       );
 
       expect(result.success).toBe(true);
@@ -284,7 +460,7 @@ describe('SparkProtocol integration tests', () => {
       const mockRedeemData = '0xhash123' as `0x${string}`;
       vi.mocked(encodeFunctionData).mockReturnValue(mockRedeemData);
 
-      (smartWallet.send as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
+      (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
       const result = await sparkProtocol.withdraw(mockVaultInfo, undefined, smartWallet);
 
@@ -301,12 +477,15 @@ describe('SparkProtocol integration tests', () => {
         args: [mockMaxShares, expect.any(String), expect.any(String)],
       });
 
-      expect(smartWallet.send).toHaveBeenCalledWith(
-        {
-          to: mockVaultInfo.vaultAddress,
-          data: mockRedeemData,
-        },
+      expect(smartWallet.sendBatch).toHaveBeenCalledWith(
+        [
+          {
+            to: mockVaultInfo.vaultAddress,
+            data: mockRedeemData,
+          },
+        ],
         8453,
+        undefined,
       );
 
       expect(result.success).toBe(true);
@@ -317,7 +496,7 @@ describe('SparkProtocol integration tests', () => {
 
       await expect(
         uninitializedProtocol.withdraw(mockVaultInfo, undefined, smartWallet),
-      ).rejects.toThrow('Public client not initialized');
+      ).rejects.toThrow('Protocol must be initialized');
     });
   });
 

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
@@ -300,14 +300,6 @@ describe('SparkProtocol integration tests', () => {
       await sparkProtocol.init(chainManager);
     });
 
-    it('should throw error when public client is not initialized for max shares', async () => {
-      const uninitializedProtocol = new SparkProtocol();
-
-      await expect(
-        uninitializedProtocol.withdraw(mockVaultInfo, undefined, smartWallet),
-      ).rejects.toThrow('Public client not initialized');
-    });
-
     it('should withdraw with paymaster token when paymaster token equals withdraw token', async () => {
       const paymasterToken = mockVaultInfo.tokenAddress;
       const mockPublicClient = chainManager.getPublicClient(8453);
@@ -324,7 +316,7 @@ describe('SparkProtocol integration tests', () => {
 
       (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
-      const result = await sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet, {
+      const result = await sparkProtocol.withdraw(mockVaultInfo, smartWallet, '500', {
         paymasterToken,
       });
 
@@ -359,7 +351,7 @@ describe('SparkProtocol integration tests', () => {
       );
 
       await expect(
-        sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet, { paymasterToken }),
+        sparkProtocol.withdraw(mockVaultInfo, smartWallet, '500', { paymasterToken }),
       ).rejects.toThrow('Insufficient wallet balance for gas payment');
     });
 
@@ -376,7 +368,7 @@ describe('SparkProtocol integration tests', () => {
 
       (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
-      const result = await sparkProtocol.withdraw(mockVaultInfo, '500', smartWallet);
+      const result = await sparkProtocol.withdraw(mockVaultInfo, smartWallet, '500');
 
       expect(parseUnits).toHaveBeenCalledWith('500', mockVaultInfo.tokenDecimals);
       expect(encodeFunctionData).toHaveBeenCalledWith({
@@ -413,7 +405,7 @@ describe('SparkProtocol integration tests', () => {
 
       (smartWallet.sendBatch as ReturnType<typeof vi.fn>).mockResolvedValue('0xhash456' as Hash);
 
-      const result = await sparkProtocol.withdraw(mockVaultInfo, undefined, smartWallet);
+      const result = await sparkProtocol.withdraw(mockVaultInfo, smartWallet);
 
       expect(mockPublicClient.readContract).toHaveBeenCalledWith({
         address: mockVaultInfo.vaultAddress,
@@ -445,9 +437,9 @@ describe('SparkProtocol integration tests', () => {
     it('should throw error when public client is not initialized for max shares', async () => {
       const uninitializedProtocol = new SparkProtocol();
 
-      await expect(
-        uninitializedProtocol.withdraw(mockVaultInfo, undefined, smartWallet),
-      ).rejects.toThrow('Public client not initialized');
+      await expect(uninitializedProtocol.withdraw(mockVaultInfo, smartWallet)).rejects.toThrow(
+        'Public client not initialized',
+      );
     });
   });
 

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.ts
@@ -19,6 +19,7 @@ import {
   SPARK_VAULT,
 } from '@/protocols/constants/spark';
 import type { VaultBalance, VaultInfo, Vaults, VaultTxnResult } from '@/types/protocols/general';
+import { GAS_RESERVE_MINIMUM, GAS_RESERVE_PERCENTAGE } from '@/constants/paymaster';
 
 /**
  * @internal
@@ -133,25 +134,12 @@ export class SparkProtocol extends BaseProtocol {
       options?.paymasterToken &&
       options.paymasterToken.toLowerCase() === depositTokenAddress.toLowerCase()
     ) {
-      this.ensureInitialized();
-      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
-      const balance = await publicClient.readContract({
-        address: depositTokenAddress,
-        abi: erc20Abi,
-        functionName: 'balanceOf',
-        args: [currentAddress],
-      });
-
-      // Reserve ~1% for gas payment (minimum 1 unit)
-      const gasReserve = balance / 100n > 0n ? balance / 100n : 1n;
-      const maxDepositAmount = balance > gasReserve ? balance - gasReserve : 0n;
-
-      if (rawDepositAmount > maxDepositAmount) {
-        const maxDepositFormatted = Number(maxDepositAmount) / 10 ** depositTokenDecimals;
-        throw new Error(
-          `Insufficient balance. Must reserve tokens for gas payment. Max deposit: ${maxDepositFormatted.toFixed(depositTokenDecimals)}`,
-        );
-      }
+      await this.validateGasReserve(
+        depositTokenAddress,
+        currentAddress,
+        depositTokenDecimals,
+        rawDepositAmount,
+      );
     }
 
     const allowance = await this.checkAllowance(
@@ -215,26 +203,7 @@ export class SparkProtocol extends BaseProtocol {
       options?.paymasterToken &&
       options.paymasterToken.toLowerCase() === tokenAddress.toLowerCase()
     ) {
-      this.ensureInitialized();
-      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
-      const walletBalance = await publicClient.readContract({
-        address: tokenAddress,
-        abi: erc20Abi,
-        functionName: 'balanceOf',
-        args: [currentAddress],
-      });
-
-      // Reserve ~1% for gas payment (minimum 1 unit)
-      // The wallet must have enough balance BEFORE withdrawal to pay for gas
-      const gasReserve = walletBalance / 100n > 0n ? walletBalance / 100n : 1n;
-      const minRequiredBalance = gasReserve;
-
-      if (walletBalance < minRequiredBalance) {
-        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** tokenDecimals;
-        throw new Error(
-          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(tokenDecimals)} tokens to pay for gas before withdrawal.`,
-        );
-      }
+      await this.validateGasReserve(tokenAddress, currentAddress, tokenDecimals);
     }
 
     // Check allowance of sUSDC shares (vaultAddress) for the vault (vaultAddress)
@@ -289,6 +258,81 @@ export class SparkProtocol extends BaseProtocol {
     const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!, options);
 
     return { success: true, hash };
+  }
+
+  /**
+   * Validate gas reserve balance for operations using paymaster
+   * Ensures sufficient balance remains for gas payment when using paymaster with the same token
+   * @param tokenAddress Token address to check balance for
+   * @param walletAddress Wallet address to check
+   * @param tokenDecimals Number of decimals for the token
+   * @param operationAmount Optional: Amount for deposit operation (in token units). If provided, validates deposit; otherwise validates withdraw
+   * @throws Error if balance is insufficient for gas payment or operation
+   */
+  private async validateGasReserve(
+    tokenAddress: Address,
+    walletAddress: Address,
+    tokenDecimals: number,
+    operationAmount?: bigint,
+  ): Promise<void> {
+    this.ensureInitialized();
+    const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
+    const balance = await publicClient.readContract({
+      address: tokenAddress,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [walletAddress],
+    });
+
+    const gasReserve = this.calculateGasReserve(balance, tokenDecimals);
+
+    if (operationAmount !== undefined) {
+      // Deposit validation: check if operation amount exceeds available balance after gas reserve
+      const maxDepositAmount = balance > gasReserve ? balance - gasReserve : 0n;
+
+      if (operationAmount > maxDepositAmount) {
+        const maxDepositFormatted = Number(maxDepositAmount) / 10 ** tokenDecimals;
+        throw new Error(
+          `Insufficient balance. Must reserve tokens for gas payment. Max deposit: ${maxDepositFormatted.toFixed(tokenDecimals)}`,
+        );
+      }
+    } else {
+      // Withdraw validation: check if balance meets minimum gas reserve requirement
+      const minRequiredBalance = gasReserve;
+
+      if (balance < minRequiredBalance) {
+        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** tokenDecimals;
+        throw new Error(
+          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(tokenDecimals)} tokens to pay for gas before withdrawal.`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Calculate gas reserve amount based on balance and token decimals
+   * Uses a more sophisticated calculation that considers token decimal places:
+   * - For tokens with low decimals (≤8): Uses a fixed minimum amount (e.g., 0.001 tokens)
+   * - For tokens with high decimals (>8): Uses 1% of balance with a minimum of 1 unit
+   * @param balance Current token balance
+   * @param tokenDecimals Number of decimals for the token
+   * @returns Gas reserve amount in token units
+   */
+  private calculateGasReserve(balance: bigint, tokenDecimals: number): bigint {
+    // For tokens with low decimals (e.g., WBTC with 8 decimals), use a fixed minimum
+    // This ensures sufficient gas coverage for high-value tokens
+    if (tokenDecimals <= 6) {
+      // Reserve 0.001 tokens (or 1 unit if that's larger)
+      const fixedReserve = parseUnits(GAS_RESERVE_MINIMUM.toString(), tokenDecimals);
+      const oneUnit = 1n;
+      return fixedReserve > oneUnit ? fixedReserve : oneUnit;
+    }
+
+    // For tokens with high decimals, use percentage-based approach
+    // Reserve 1% of balance with a minimum of 1 unit
+    const percentageReserve = (balance * BigInt(GAS_RESERVE_PERCENTAGE)) / 100n;
+    const oneUnit = 1n;
+    return percentageReserve > 0n ? percentageReserve : oneUnit;
   }
 
   /**

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.ts
@@ -184,8 +184,8 @@ export class SparkProtocol extends BaseProtocol {
    */
   async withdraw(
     vaultInfo: VaultInfo,
-    amount: string | undefined,
     smartWallet: SmartWallet,
+    amount?: string,
     options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult> {
     const currentAddress = await smartWallet.getAddress();

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.ts
@@ -2,7 +2,14 @@ import { BaseProtocol } from '@/protocols/base/BaseProtocol';
 import type { ChainManager } from '@/tools/ChainManager';
 import type { SmartWallet } from '@/wallet/base/wallets/SmartWallet';
 
-import { type Address, encodeFunctionData, erc20Abi, formatUnits, parseUnits } from 'viem';
+import {
+  type Address,
+  encodeFunctionData,
+  erc20Abi,
+  formatUnits,
+  maxUint256,
+  parseUnits,
+} from 'viem';
 
 import { SPARK_VAULT_ABI, SPARK_SSR_ORACLE_ABI } from '@/abis/protocols/spark';
 import {
@@ -110,39 +117,75 @@ export class SparkProtocol extends BaseProtocol {
     vaultInfo: VaultInfo,
     amount: string,
     smartWallet: SmartWallet,
+    options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult> {
-    const owner = await smartWallet.getAddress();
-    const assets = parseUnits(amount, vaultInfo.tokenDecimals);
+    const currentAddress = await smartWallet.getAddress();
+    const depositTokenDecimals = vaultInfo.tokenDecimals;
+    const depositTokenAddress = vaultInfo.tokenAddress;
+    const vaultAddress = vaultInfo.vaultAddress;
+
+    const rawDepositAmount = parseUnits(amount, vaultInfo.tokenDecimals);
+
+    const operationsCallData = [];
+
+    // If paymaster token and deposit token are the same, reserve balance for gas
+    if (
+      options?.paymasterToken &&
+      options.paymasterToken.toLowerCase() === depositTokenAddress.toLowerCase()
+    ) {
+      this.ensureInitialized();
+      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
+      const balance = await publicClient.readContract({
+        address: depositTokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [currentAddress],
+      });
+
+      // Reserve ~1% for gas payment (minimum 1 unit)
+      const gasReserve = balance / 100n > 0n ? balance / 100n : 1n;
+      const maxDepositAmount = balance > gasReserve ? balance - gasReserve : 0n;
+
+      if (rawDepositAmount > maxDepositAmount) {
+        const maxDepositFormatted = Number(maxDepositAmount) / 10 ** depositTokenDecimals;
+        throw new Error(
+          `Insufficient balance. Must reserve tokens for gas payment. Max deposit: ${maxDepositFormatted.toFixed(depositTokenDecimals)}`,
+        );
+      }
+    }
 
     const allowance = await this.checkAllowance(
-      vaultInfo.tokenAddress,
-      vaultInfo.vaultAddress,
-      owner,
+      depositTokenAddress,
+      vaultAddress,
+      currentAddress,
       this.selectedChainId!,
     );
 
-    const ops: { to: Address; data: `0x${string}` }[] = [];
-
-    if (allowance < assets) {
-      ops.push({
-        to: vaultInfo.tokenAddress,
+    if (allowance < rawDepositAmount) {
+      const approveData = {
+        to: depositTokenAddress,
         data: encodeFunctionData({
           abi: erc20Abi,
           functionName: 'approve',
-          args: [vaultInfo.vaultAddress, assets],
+          args: [vaultAddress, rawDepositAmount],
         }),
-      });
+      };
+
+      operationsCallData.push(approveData);
     }
-    ops.push({
-      to: vaultInfo.vaultAddress,
+
+    const depositData = {
+      to: vaultAddress,
       data: encodeFunctionData({
         abi: SPARK_VAULT_ABI,
         functionName: 'deposit',
-        args: [assets, owner] as const,
+        args: [rawDepositAmount, currentAddress] as const,
       }),
-    });
+    };
 
-    const hash = await smartWallet.sendBatch(ops, this.selectedChainId!);
+    operationsCallData.push(depositData);
+
+    const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!, options);
     return { success: true, hash };
   }
 
@@ -158,36 +201,92 @@ export class SparkProtocol extends BaseProtocol {
     vaultInfo: VaultInfo,
     amount: string | undefined,
     smartWallet: SmartWallet,
+    options?: { paymasterToken?: Address },
   ): Promise<VaultTxnResult> {
-    const owner = await smartWallet.getAddress();
+    const currentAddress = await smartWallet.getAddress();
 
-    let withdrawData: { to: Address; data: `0x${string}` };
+    const tokenDecimals = vaultInfo.tokenDecimals;
+    const tokenAddress = vaultInfo.tokenAddress;
+    const vaultAddress = vaultInfo.vaultAddress;
 
+    const operationsCallData = [];
+
+    if (
+      options?.paymasterToken &&
+      options.paymasterToken.toLowerCase() === tokenAddress.toLowerCase()
+    ) {
+      this.ensureInitialized();
+      const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
+      const walletBalance = await publicClient.readContract({
+        address: tokenAddress,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [currentAddress],
+      });
+
+      // Reserve ~1% for gas payment (minimum 1 unit)
+      // The wallet must have enough balance BEFORE withdrawal to pay for gas
+      const gasReserve = walletBalance / 100n > 0n ? walletBalance / 100n : 1n;
+      const minRequiredBalance = gasReserve;
+
+      if (walletBalance < minRequiredBalance) {
+        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** tokenDecimals;
+        throw new Error(
+          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(tokenDecimals)} tokens to pay for gas before withdrawal.`,
+        );
+      }
+    }
+
+    // Check allowance of sUSDC shares (vaultAddress) for the vault (vaultAddress)
+    // In ERC-4626, the vault contract IS the share token
+    const allowance = await this.checkAllowance(
+      vaultAddress, // sUSDC shares token address (same as vault)
+      vaultAddress, // vault address (needs approval to spend shares)
+      currentAddress,
+      this.selectedChainId!,
+    );
+
+    // Approve vault to spend sUSDC shares if needed
+    if (allowance === 0n) {
+      const approveData = {
+        to: vaultAddress, // sUSDC share token
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [vaultAddress, maxUint256], // Approve vault to spend shares
+        }),
+      };
+      operationsCallData.push(approveData);
+    }
+
+    let withdrawCallData;
     if (amount) {
-      const assets = parseUnits(amount, vaultInfo.tokenDecimals);
+      const rawWithdrawAmount = parseUnits(amount, tokenDecimals);
 
-      withdrawData = {
-        to: vaultInfo.vaultAddress,
+      withdrawCallData = {
+        to: vaultAddress,
         data: encodeFunctionData({
           abi: SPARK_VAULT_ABI,
           functionName: 'withdraw',
-          args: [assets, owner, owner] as const,
+          args: [rawWithdrawAmount, currentAddress, currentAddress] as const,
         }),
       };
     } else {
-      const maxShares = await this.getMaxRedeemableShares(vaultInfo, owner);
+      const maxShares = await this.getMaxRedeemableShares(vaultInfo, currentAddress);
 
-      withdrawData = {
-        to: vaultInfo.vaultAddress,
+      withdrawCallData = {
+        to: vaultAddress,
         data: encodeFunctionData({
           abi: SPARK_VAULT_ABI,
           functionName: 'redeem',
-          args: [maxShares, owner, owner] as const,
+          args: [maxShares, currentAddress, currentAddress] as const,
         }),
       };
     }
 
-    const hash = await smartWallet.send(withdrawData, this.selectedChainId!);
+    operationsCallData.push(withdrawCallData);
+
+    const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!, options);
 
     return { success: true, hash };
   }

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.ts
@@ -2,14 +2,7 @@ import { BaseProtocol } from '@/protocols/base/BaseProtocol';
 import type { ChainManager } from '@/tools/ChainManager';
 import type { SmartWallet } from '@/wallet/base/wallets/SmartWallet';
 
-import {
-  type Address,
-  encodeFunctionData,
-  erc20Abi,
-  formatUnits,
-  maxUint256,
-  parseUnits,
-} from 'viem';
+import { type Address, encodeFunctionData, erc20Abi, formatUnits, parseUnits } from 'viem';
 
 import { SPARK_VAULT_ABI, SPARK_SSR_ORACLE_ABI } from '@/abis/protocols/spark';
 import {
@@ -19,7 +12,7 @@ import {
   SPARK_VAULT,
 } from '@/protocols/constants/spark';
 import type { VaultBalance, VaultInfo, Vaults, VaultTxnResult } from '@/types/protocols/general';
-import { GAS_RESERVE_MINIMUM, GAS_RESERVE_PERCENTAGE } from '@/constants/paymaster';
+import type { TransactionData } from '@/types/transaction';
 
 /**
  * @internal
@@ -42,7 +35,7 @@ export class SparkProtocol extends BaseProtocol {
     this.chainManager = chainManager;
     this.selectedChainId = chainManager.getSupportedChain();
 
-    this.publicClient = chainManager.getPublicClient(this.selectedChainId!);
+    this.publicClient = chainManager.getPublicClient(this.getSelectedChainId());
 
     this.allVaults = SPARK_VAULT;
   }
@@ -127,9 +120,9 @@ export class SparkProtocol extends BaseProtocol {
 
     const rawDepositAmount = parseUnits(amount, vaultInfo.tokenDecimals);
 
-    const operationsCallData = [];
+    const operationsCallData: TransactionData[] = [];
 
-    // If paymaster token and deposit token are the same, reserve balance for gas
+    // If paymaster token and deposit token are the same, validate gas reserve balance
     if (
       options?.paymasterToken &&
       options.paymasterToken.toLowerCase() === depositTokenAddress.toLowerCase()
@@ -146,7 +139,7 @@ export class SparkProtocol extends BaseProtocol {
       depositTokenAddress,
       vaultAddress,
       currentAddress,
-      this.selectedChainId!,
+      this.getSelectedChainId(),
     );
 
     if (allowance < rawDepositAmount) {
@@ -173,7 +166,11 @@ export class SparkProtocol extends BaseProtocol {
 
     operationsCallData.push(depositData);
 
-    const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!, options);
+    const hash = await smartWallet.sendBatch(
+      operationsCallData,
+      this.getSelectedChainId(),
+      options,
+    );
     return { success: true, hash };
   }
 
@@ -197,8 +194,9 @@ export class SparkProtocol extends BaseProtocol {
     const tokenAddress = vaultInfo.tokenAddress;
     const vaultAddress = vaultInfo.vaultAddress;
 
-    const operationsCallData = [];
+    const operationsCallData: TransactionData[] = [];
 
+    // If paymaster token and withdraw token are the same, validate gas reserve balance
     if (
       options?.paymasterToken &&
       options.paymasterToken.toLowerCase() === tokenAddress.toLowerCase()
@@ -206,29 +204,7 @@ export class SparkProtocol extends BaseProtocol {
       await this.validateGasReserve(tokenAddress, currentAddress, tokenDecimals);
     }
 
-    // Check allowance of sUSDC shares (vaultAddress) for the vault (vaultAddress)
-    // In ERC-4626, the vault contract IS the share token
-    const allowance = await this.checkAllowance(
-      vaultAddress, // sUSDC shares token address (same as vault)
-      vaultAddress, // vault address (needs approval to spend shares)
-      currentAddress,
-      this.selectedChainId!,
-    );
-
-    // Approve vault to spend sUSDC shares if needed
-    if (allowance === 0n) {
-      const approveData = {
-        to: vaultAddress, // sUSDC share token
-        data: encodeFunctionData({
-          abi: erc20Abi,
-          functionName: 'approve',
-          args: [vaultAddress, maxUint256], // Approve vault to spend shares
-        }),
-      };
-      operationsCallData.push(approveData);
-    }
-
-    let withdrawCallData;
+    let withdrawCallData: TransactionData;
     if (amount) {
       const rawWithdrawAmount = parseUnits(amount, tokenDecimals);
 
@@ -255,84 +231,13 @@ export class SparkProtocol extends BaseProtocol {
 
     operationsCallData.push(withdrawCallData);
 
-    const hash = await smartWallet.sendBatch(operationsCallData, this.selectedChainId!, options);
+    const hash = await smartWallet.sendBatch(
+      operationsCallData,
+      this.getSelectedChainId(),
+      options,
+    );
 
     return { success: true, hash };
-  }
-
-  /**
-   * Validate gas reserve balance for operations using paymaster
-   * Ensures sufficient balance remains for gas payment when using paymaster with the same token
-   * @param tokenAddress Token address to check balance for
-   * @param walletAddress Wallet address to check
-   * @param tokenDecimals Number of decimals for the token
-   * @param operationAmount Optional: Amount for deposit operation (in token units). If provided, validates deposit; otherwise validates withdraw
-   * @throws Error if balance is insufficient for gas payment or operation
-   */
-  private async validateGasReserve(
-    tokenAddress: Address,
-    walletAddress: Address,
-    tokenDecimals: number,
-    operationAmount?: bigint,
-  ): Promise<void> {
-    this.ensureInitialized();
-    const publicClient = this.chainManager!.getPublicClient(this.selectedChainId!);
-    const balance = await publicClient.readContract({
-      address: tokenAddress,
-      abi: erc20Abi,
-      functionName: 'balanceOf',
-      args: [walletAddress],
-    });
-
-    const gasReserve = this.calculateGasReserve(balance, tokenDecimals);
-
-    if (operationAmount !== undefined) {
-      // Deposit validation: check if operation amount exceeds available balance after gas reserve
-      const maxDepositAmount = balance > gasReserve ? balance - gasReserve : 0n;
-
-      if (operationAmount > maxDepositAmount) {
-        const maxDepositFormatted = Number(maxDepositAmount) / 10 ** tokenDecimals;
-        throw new Error(
-          `Insufficient balance. Must reserve tokens for gas payment. Max deposit: ${maxDepositFormatted.toFixed(tokenDecimals)}`,
-        );
-      }
-    } else {
-      // Withdraw validation: check if balance meets minimum gas reserve requirement
-      const minRequiredBalance = gasReserve;
-
-      if (balance < minRequiredBalance) {
-        const minRequiredFormatted = Number(minRequiredBalance) / 10 ** tokenDecimals;
-        throw new Error(
-          `Insufficient wallet balance for gas payment. Wallet needs at least ${minRequiredFormatted.toFixed(tokenDecimals)} tokens to pay for gas before withdrawal.`,
-        );
-      }
-    }
-  }
-
-  /**
-   * Calculate gas reserve amount based on balance and token decimals
-   * Uses a more sophisticated calculation that considers token decimal places:
-   * - For tokens with low decimals (≤8): Uses a fixed minimum amount (e.g., 0.001 tokens)
-   * - For tokens with high decimals (>8): Uses 1% of balance with a minimum of 1 unit
-   * @param balance Current token balance
-   * @param tokenDecimals Number of decimals for the token
-   * @returns Gas reserve amount in token units
-   */
-  private calculateGasReserve(balance: bigint, tokenDecimals: number): bigint {
-    // For tokens with low decimals (e.g., WBTC with 8 decimals), use a fixed minimum
-    // This ensures sufficient gas coverage for high-value tokens
-    if (tokenDecimals <= 6) {
-      // Reserve 0.001 tokens (or 1 unit if that's larger)
-      const fixedReserve = parseUnits(GAS_RESERVE_MINIMUM.toString(), tokenDecimals);
-      const oneUnit = 1n;
-      return fixedReserve > oneUnit ? fixedReserve : oneUnit;
-    }
-
-    // For tokens with high decimals, use percentage-based approach
-    // Reserve 1% of balance with a minimum of 1 unit
-    const percentageReserve = (balance * BigInt(GAS_RESERVE_PERCENTAGE)) / 100n;
-    const oneUnit = 1n;
-    return percentageReserve > 0n ? percentageReserve : oneUnit;
   }
 
   /**

--- a/packages/sdk/src/tools/ApiClient.ts
+++ b/packages/sdk/src/tools/ApiClient.ts
@@ -83,7 +83,7 @@ export class ApiClient {
     operationType: OperationType,
     params?: Record<string, string>,
     protocolId?: string,
-    body?: Record<string, string | VaultInfo>,
+    body?: Record<string, string | number | VaultInfo>,
   ): Promise<ApiResponse<unknown>> {
     const { path, method } = this.operationTypeToUrlSettings[operationType];
 

--- a/packages/sdk/src/types/protocols/proxy.ts
+++ b/packages/sdk/src/types/protocols/proxy.ts
@@ -1,14 +1,9 @@
 import type { VaultInfo } from '@/types/protocols/general';
-import type { Hex } from '@privy-io/server-auth';
 import type { Address, Hash } from 'viem';
 
 export interface ProxyVaults {
   stableVaults: VaultInfo[];
   nonStableVaults: VaultInfo[];
-}
-export interface OperationCallDataType {
-  to: Address;
-  data: Hex;
 }
 
 export interface LogOperationDataResponse {

--- a/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
@@ -381,7 +381,7 @@ describe('DefaultSmartWallet integration tests', () => {
 
       const result = await wallet.withdraw(mockVaultInfo, amount);
 
-      expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet, undefined);
+      expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, wallet, amount, undefined);
       expect(result.hash).toBe(
         '0x3c36293ab6884794bda1271b570ca9e9b68a406e93486359e7213a30f88c349b',
       );
@@ -403,7 +403,7 @@ describe('DefaultSmartWallet integration tests', () => {
 
       const result = await wallet.withdraw(mockVaultInfo, amount, { paymasterToken });
 
-      expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet, {
+      expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, wallet, amount, {
         paymasterToken,
       });
       expect(result.hash).toBe(

--- a/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
@@ -264,9 +264,6 @@ describe('DefaultSmartWallet integration tests', () => {
       };
       vi.mocked(bundlerClient.estimateUserOperationGas).mockResolvedValue(mockGasEstimate);
       vi.mocked(bundlerClient.sendUserOperation).mockResolvedValue('0xTransactionHash');
-      // vi.mocked(bundlerClient.waitForUserOperationReceipt).mockResolvedValue({
-      //   receipt: {} as any,
-      // });
 
       const result = await wallet.sendBatch(transactionData, chainId);
 
@@ -343,6 +340,30 @@ describe('DefaultSmartWallet integration tests', () => {
       );
       expect(result.success).toBe(true);
     });
+
+    it('should deposit to a vault with paymaster token option', async () => {
+      const wallet = new DefaultSmartWallet(
+        mockOwners,
+        mockSigner,
+        mockChainManager,
+        mockProtocol,
+        mockCoinbaseCDP,
+      );
+
+      const depositSpy = vi.mocked(mockProtocol.deposit as ReturnType<typeof vi.fn>);
+      const amount = '1000';
+      const paymasterToken = getRandomAddress();
+
+      const result = await wallet.earn(mockVaultInfo, amount, { paymasterToken });
+
+      expect(depositSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet, {
+        paymasterToken,
+      });
+      expect(result.hash).toBe(
+        '0x3c36293ab6884794bda1271b570ca9e9b68a406e93486359e7213a30f88c349b',
+      );
+      expect(result.success).toBe(true);
+    });
   });
 
   describe('withdraw', () => {
@@ -361,6 +382,30 @@ describe('DefaultSmartWallet integration tests', () => {
       const result = await wallet.withdraw(mockVaultInfo, amount);
 
       expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet, undefined);
+      expect(result.hash).toBe(
+        '0x3c36293ab6884794bda1271b570ca9e9b68a406e93486359e7213a30f88c349b',
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('should withdraw from a vault with paymaster token option', async () => {
+      const wallet = new DefaultSmartWallet(
+        mockOwners,
+        mockSigner,
+        mockChainManager,
+        mockProtocol,
+        mockCoinbaseCDP,
+      );
+
+      const withdrawSpy = vi.mocked(mockProtocol.withdraw as ReturnType<typeof vi.fn>);
+      const amount = '1000';
+      const paymasterToken = getRandomAddress();
+
+      const result = await wallet.withdraw(mockVaultInfo, amount, { paymasterToken });
+
+      expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet, {
+        paymasterToken,
+      });
       expect(result.hash).toBe(
         '0x3c36293ab6884794bda1271b570ca9e9b68a406e93486359e7213a30f88c349b',
       );

--- a/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
@@ -337,7 +337,7 @@ describe('DefaultSmartWallet integration tests', () => {
 
       const result = await wallet.earn(mockVaultInfo, amount);
 
-      expect(depositSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet);
+      expect(depositSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet, undefined);
       expect(result.hash).toBe(
         '0x3c36293ab6884794bda1271b570ca9e9b68a406e93486359e7213a30f88c349b',
       );
@@ -360,7 +360,7 @@ describe('DefaultSmartWallet integration tests', () => {
 
       const result = await wallet.withdraw(mockVaultInfo, amount);
 
-      expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet);
+      expect(withdrawSpy).toHaveBeenCalledWith(mockVaultInfo, amount, wallet, undefined);
       expect(result.hash).toBe(
         '0x3c36293ab6884794bda1271b570ca9e9b68a406e93486359e7213a30f88c349b',
       );

--- a/packages/sdk/src/wallet/DefaultSmartWallet.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.ts
@@ -241,8 +241,8 @@ export class DefaultSmartWallet extends SmartWallet {
   ): Promise<VaultTxnResult> {
     const withdrawTransactionResult = await this.protocolProvider.withdraw(
       vaultInfo,
-      amount,
       this,
+      amount,
       options,
     );
 

--- a/packages/sdk/src/wallet/DefaultSmartWallet.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.ts
@@ -191,12 +191,21 @@ export class DefaultSmartWallet extends SmartWallet {
    * @remarks
    * The protocol is selected on the SDK initialization step
    * @param amount Human-readable amount string
+   * @param options Optional parameters
+   * @param options.paymasterToken ERC-20 token address to use for gas payment (e.g., USDC)
    * @returns Transaction result for the deposit
    */
-  async earn(vaultInfo: VaultInfo, amount: string): Promise<VaultTxnResult> {
-    this.chainManager.getSupportedChain();
-
-    const depositTransactionResult = this.protocolProvider.deposit(vaultInfo, amount, this);
+  async earn(
+    vaultInfo: VaultInfo,
+    amount: string,
+    options?: { paymasterToken?: Address },
+  ): Promise<VaultTxnResult> {
+    const depositTransactionResult = this.protocolProvider.deposit(
+      vaultInfo,
+      amount,
+      this,
+      options,
+    );
 
     return depositTransactionResult;
   }
@@ -219,12 +228,23 @@ export class DefaultSmartWallet extends SmartWallet {
    * @public
    * @category Earn
    * @param amount Human-readable amount string
+   * @param options Optional parameters
+   * @param options.paymasterToken ERC-20 token address to use for gas payment (e.g., USDC)
    * @returns Transaction result for the withdrawal
    * @throws Error if the withdrawal fails
    * @throws Error a user didn't deposit anything
    */
-  async withdraw(vaultInfo: VaultInfo, amount: string): Promise<VaultTxnResult> {
-    const withdrawTransactionResult = await this.protocolProvider.withdraw(vaultInfo, amount, this);
+  async withdraw(
+    vaultInfo: VaultInfo,
+    amount: string,
+    options?: { paymasterToken?: Address },
+  ): Promise<VaultTxnResult> {
+    const withdrawTransactionResult = await this.protocolProvider.withdraw(
+      vaultInfo,
+      amount,
+      this,
+      options,
+    );
 
     return withdrawTransactionResult;
   }

--- a/packages/sdk/src/wallet/base/wallets/SmartWallet.ts
+++ b/packages/sdk/src/wallet/base/wallets/SmartWallet.ts
@@ -111,9 +111,15 @@ export abstract class SmartWallet {
    * @internal
    * @category Yield
    * @param amount Amount to deposit in human-readable format
+   * @param options Optional parameters
+   * @param options.paymasterToken ERC-20 token address to use for gas payment (e.g., USDC)
    * @returns Promise resolving to a {@link VaultTxnResult}
    */
-  abstract earn(vaultInfo: VaultInfo, amount: string): Promise<VaultTxnResult>;
+  abstract earn(
+    vaultInfo: VaultInfo,
+    amount: string,
+    options?: { paymasterToken?: Address },
+  ): Promise<VaultTxnResult>;
 
   /**
    * Retrieves the balance of deposited funds in the selected protocol vault
@@ -130,9 +136,15 @@ export abstract class SmartWallet {
    * @internal
    * @category Yield
    * @param amount Human-readable amount of shares to withdraw
+   * @param options Optional parameters
+   * @param options.paymasterToken ERC-20 token address to use for gas payment (e.g., USDC)
    * @returns Promise resolving to a {@link VaultTxnResult}
    */
-  abstract withdraw(vaultInfo: VaultInfo, amount: string): Promise<VaultTxnResult>;
+  abstract withdraw(
+    vaultInfo: VaultInfo,
+    amount: string,
+    options?: { paymasterToken?: Address },
+  ): Promise<VaultTxnResult>;
 
   /**
    * Funds the smart wallet with the specified amount of the specified token via Coinbase CDP on-ramp service


### PR DESCRIPTION
## What was done?

1. Added paymaster to ProxyProtocol to use with DeFi opportunities with Mycelium Cloud
2. Updated tests for ProxyProtocol
3. Added Paymaster support for DefaultSmartWallet
4. Updated tests for DefaultSmartWallet.ts


TODO: 

- [x] Support paymaster for Spark
- [x] Change tests for Spark and ProxyProtocol
- [x] Added to documentation the usage of paymaster 