### PR TITLE
chore: balance sdk method refactoring

### DIFF
--- a/.changeset/spotty-crabs-listen.md
+++ b/.changeset/spotty-crabs-listen.md
@@ -1,0 +1,20 @@
+---
+'@mycelium-sdk/core': major
+---
+
+## What was changed?
+
+- Introduced AddressBalance: balance is now returned as:{ overall: OverallAddressBalance; perVault: VaultBalance[] } instead of VaultBalance[]
+- getBalances() (SparkProtocol, ProxyProtocol) now returns AddressBalance (overall totals plus per-vault list)
+- getEarnBalances() on the wallet now returns AddressBalance instead of VaultBalance[]
+- AddressBalance is exported from the SDK public types
+
+## Why was changed/added?
+
+- Mycelium Cloud started to return a different format of data for the balance
+- Callers need both an aggregated view (overall balance) and per-vault breakdown; a single type with overall and perVault supports both without extra requests
+- Aligns protocol and wallet APIs and keeps balance shape consistent across the SDK
+
+## How to use the change?
+
+Use the new return type: result.overall for aggregated numbers, result.perVault for the list of vault balances (same structure as before, but under perVault). Example: const { overall, perVault } = await wallet.getEarnBalances(); and then use perVault[0].balance, perVault[0].vaultInfo, etc. Replace any code that treated the result as a plain array (e.g. result[0]) with result.perVault[0] and use result.overall when you need totals

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,8 +4,9 @@ import {
   type MyceliumSDKConfig,
   type ProxyBalance,
   type SmartWallet,
-  type VaultBalance,
+  type AddressBalance,
   type Vaults,
+  type VaultBalance,
 } from '@mycelium-sdk/core';
 import { formatBalancesToDisplay, formatVaultInfoToDisplay, getEnv } from './utils/formatters';
 import { WalletDatabase } from './libs/database';
@@ -241,16 +242,16 @@ export class CLI {
       return;
     }
 
-    const earningBalances = (await this.wallet.getEarnBalances()) as VaultBalance[];
+    const earningBalances = (await this.wallet.getEarnBalances()) as AddressBalance;
 
     if (!earningBalances) {
       logError('No earning balances found. You have not deposited any funds yet');
       return;
     }
 
-    const formattedBalances = earningBalances
-      .filter((balance) => balance.balance !== null)
-      .map((balance) => {
+    const formattedBalances = earningBalances.perVault
+      .filter((balance: VaultBalance) => balance.balance !== null)
+      .map((balance: VaultBalance) => {
         const currentBalance = balance.balance as ProxyBalance;
         return {
           vaultInfo: balance.vaultInfo,
@@ -371,7 +372,7 @@ export class CLI {
       return;
     }
 
-    const balances = [...earningBalances].map((vault, index) => {
+    const balances = earningBalances.perVault.map((vault: VaultBalance, index: number) => {
       const currentBalance = vault.balance as ProxyBalance;
       return {
         optionId: index + 1,

--- a/packages/sdk/src/protocols/base/BaseProtocol.ts
+++ b/packages/sdk/src/protocols/base/BaseProtocol.ts
@@ -15,10 +15,10 @@ import type { SupportedChainId } from '@/constants/chains';
 import type { SmartWallet } from '@/wallet/base/wallets/SmartWallet';
 import type {
   VaultInfo,
-  VaultBalance,
   VaultTxnResult,
   Vaults,
   ProtocolsSecurityConfig,
+  AddressBalance,
 } from '@/types/protocols/general';
 import type { ApiClient } from '@/tools/ApiClient';
 
@@ -108,7 +108,7 @@ export abstract class BaseProtocol {
    * @param protocolId Protocol ID to get balances for
    * @returns Balance of deposited funds
    */
-  abstract getBalances(walletAddress: Address, protocolId?: string): Promise<VaultBalance[]>;
+  abstract getBalances(walletAddress: Address, protocolId?: string): Promise<AddressBalance>;
 
   /**
    * Approve a token for protocol use

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.spec.ts
@@ -6,6 +6,7 @@ import type { ChainManager } from '@mycelium-sdk/core/tools/ChainManager';
 import type { ApiClient } from '@mycelium-sdk/core/tools/ApiClient';
 import type { SmartWallet } from '@mycelium-sdk/core/wallet/base/wallets/SmartWallet';
 import type {
+  AddressBalance,
   ProtocolsSecurityConfig,
   VaultInfo,
   VaultBalance,
@@ -62,6 +63,14 @@ describe('ProxyProtocol integration tests', () => {
     earned30dUpdatedAt: '2024-01-01T00:00:00Z',
     earned90dUpdatedAt: '2024-01-01T00:00:00Z',
   };
+
+  const createMockAddressBalance = (perVault: VaultBalance[]): AddressBalance => ({
+    overall: {
+      currentBalance: 1000,
+      actualCurrentBalance: 1000,
+    },
+    perVault,
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -380,14 +389,9 @@ describe('ProxyProtocol integration tests', () => {
     });
 
     it('should withdraw specified amount from vault', async () => {
-      const mockEarningBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
-
-      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(
+        createMockAddressBalance([{ vaultInfo: mockVaultInfo, balance: mockProxyBalance }]),
+      );
 
       const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
@@ -419,14 +423,9 @@ describe('ProxyProtocol integration tests', () => {
     });
 
     it('should withdraw all balance when amount is not specified', async () => {
-      const mockEarningBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
-
-      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(
+        createMockAddressBalance([{ vaultInfo: mockVaultInfo, balance: mockProxyBalance }]),
+      );
 
       const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
@@ -464,14 +463,11 @@ describe('ProxyProtocol integration tests', () => {
     });
 
     it('should throw error when vault balance not found in earning balances', async () => {
-      const mockEarningBalances: VaultBalance[] = [
-        {
-          vaultInfo: { ...mockVaultInfo, id: 'different-vault' },
-          balance: mockProxyBalance,
-        },
-      ];
-
-      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(
+        createMockAddressBalance([
+          { vaultInfo: { ...mockVaultInfo, id: 'different-vault' }, balance: mockProxyBalance },
+        ]),
+      );
 
       await expect(proxyProtocol.withdraw(mockVaultInfo, smartWallet, '500')).rejects.toThrow(
         'No earning balance found',
@@ -479,14 +475,9 @@ describe('ProxyProtocol integration tests', () => {
     });
 
     it('should throw error when API fails to return withdraw operations', async () => {
-      const mockEarningBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
-
-      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(
+        createMockAddressBalance([{ vaultInfo: mockVaultInfo, balance: mockProxyBalance }]),
+      );
 
       (apiClient.sendRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: false,
@@ -499,14 +490,9 @@ describe('ProxyProtocol integration tests', () => {
     });
 
     it('should log operation after successful withdrawal', async () => {
-      const mockEarningBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
-
-      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(
+        createMockAddressBalance([{ vaultInfo: mockVaultInfo, balance: mockProxyBalance }]),
+      );
 
       const mockOperationData: TransactionData = {
         to: mockVaultInfo.vaultAddress,
@@ -541,14 +527,10 @@ describe('ProxyProtocol integration tests', () => {
     it('should withdraw with paymaster token when paymaster token equals withdraw token', async () => {
       const paymasterToken = mockVaultInfo.tokenAddress;
       const mockPublicClient = chainManager.getPublicClient(8453);
-      const mockEarningBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
 
-      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(
+        createMockAddressBalance([{ vaultInfo: mockVaultInfo, balance: mockProxyBalance }]),
+      );
 
       // Mock balance check for gas reserve
       vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
@@ -591,14 +573,10 @@ describe('ProxyProtocol integration tests', () => {
     it('should throw error when wallet balance is insufficient for gas payment', async () => {
       const paymasterToken = mockVaultInfo.tokenAddress;
       const mockPublicClient = chainManager.getPublicClient(8453);
-      const mockEarningBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
 
-      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(mockEarningBalances);
+      vi.mocked(smartWallet.getEarnBalances).mockResolvedValue(
+        createMockAddressBalance([{ vaultInfo: mockVaultInfo, balance: mockProxyBalance }]),
+      );
 
       // Mock balance that's too low for gas reserve
       vi.mocked(mockPublicClient.readContract as ReturnType<typeof vi.fn>).mockResolvedValue(
@@ -618,16 +596,13 @@ describe('ProxyProtocol integration tests', () => {
 
     it('should fetch and return earning balances of a user by a provided address', async () => {
       const walletAddress = '0x1234567890123456789012345678901234567890' as Address;
-      const mockBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
+      const mockAddressBalance = createMockAddressBalance([
+        { vaultInfo: mockVaultInfo, balance: mockProxyBalance },
+      ]);
 
       (apiClient.sendRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true,
-        data: mockBalances,
+        data: mockAddressBalance,
       });
 
       const result = await proxyProtocol.getBalances(walletAddress);
@@ -638,21 +613,18 @@ describe('ProxyProtocol integration tests', () => {
         userAddress: walletAddress,
       });
 
-      expect(result).toEqual(mockBalances);
+      expect(result).toEqual(mockAddressBalance);
     });
 
     it('should fetch balances for specific protocol ID', async () => {
       const walletAddress = '0x1234567890123456789012345678901234567890' as Address;
-      const mockBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: mockProxyBalance,
-        },
-      ];
+      const mockAddressBalance = createMockAddressBalance([
+        { vaultInfo: mockVaultInfo, balance: mockProxyBalance },
+      ]);
 
       (apiClient.sendRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true,
-        data: mockBalances,
+        data: mockAddressBalance,
       });
 
       await proxyProtocol.getBalances(walletAddress, 'spark');

--- a/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/ProxyProtocol.ts
@@ -1,8 +1,8 @@
 import { BaseProtocol } from '@/protocols/base/BaseProtocol';
 import type { ChainManager } from '@/tools/ChainManager';
 import type {
+  AddressBalance,
   ProtocolsSecurityConfig,
-  VaultBalance,
   VaultInfo,
   Vaults,
   VaultTxnResult,
@@ -259,7 +259,9 @@ export class ProxyProtocol extends BaseProtocol {
       throw new Error('No earning balances found');
     }
 
-    const earningBalance = earningBalances.find((balance) => balance.vaultInfo.id === vaultInfo.id);
+    const earningBalance = earningBalances.perVault.find(
+      (balance) => balance.vaultInfo.id === vaultInfo.id,
+    );
 
     if (!earningBalance) {
       throw new Error('No earning balance found');
@@ -320,7 +322,7 @@ export class ProxyProtocol extends BaseProtocol {
    * @param protocolId Protocol ID to get the balances for. Optional, default is undefined
    * @returns Balances of the user in the protocol vaults
    */
-  async getBalances(walletAddress: Address, protocolId?: string): Promise<VaultBalance[]> {
+  async getBalances(walletAddress: Address, protocolId?: string): Promise<AddressBalance> {
     const pathParams = {
       chain_id: this.getSelectedChainId().toString(),
       protocol_id: protocolId || '',
@@ -333,7 +335,7 @@ export class ProxyProtocol extends BaseProtocol {
       throw new Error(apiResponse.error || 'Failed to get balances');
     }
 
-    const balances: VaultBalance[] = apiResponse.data as unknown as VaultBalance[];
+    const balances: AddressBalance = apiResponse.data as unknown as AddressBalance;
 
     return balances;
   }

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
@@ -496,7 +496,7 @@ describe('SparkProtocol integration tests', () => {
       expect(typeof result.perVault[0]?.vaultInfo.metadata?.apy).toBe('number');
     });
 
-    it('should return null balance when wallet has no shares', async () => {
+    it('should return zero overall and perVault balance when wallet has no shares', async () => {
       const walletAddress = '0x1234567890123456789012345678901234567890' as Address;
       const mockPublicClient = chainManager.getPublicClient(8453);
       const mockSSR = BigInt('1050000000000000000000000000');

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.spec.ts
@@ -488,11 +488,12 @@ describe('SparkProtocol integration tests', () => {
 
       expect(formatUnits).toHaveBeenCalledWith(mockAssets, mockVaultInfo.tokenDecimals);
 
-      expect(result).toHaveLength(1);
-      expect(result[0]?.vaultInfo.id).toBe('sUSDC');
-      expect(result[0]?.balance).toBe('1050.0');
-      expect(result[0]?.vaultInfo.metadata?.apy).toBeDefined();
-      expect(typeof result[0]?.vaultInfo.metadata?.apy).toBe('number');
+      expect(result.overall).toEqual({ currentBalance: 1050, actualCurrentBalance: 1050 });
+      expect(result.perVault).toHaveLength(1);
+      expect(result.perVault[0]?.vaultInfo.id).toBe('sUSDC');
+      expect(result.perVault[0]?.balance).toBe('1050.0');
+      expect(result.perVault[0]?.vaultInfo.metadata?.apy).toBeDefined();
+      expect(typeof result.perVault[0]?.vaultInfo.metadata?.apy).toBe('number');
     });
 
     it('should return null balance when wallet has no shares', async () => {
@@ -512,11 +513,12 @@ describe('SparkProtocol integration tests', () => {
         functionName: 'getSSR',
       });
 
-      expect(result).toHaveLength(1);
-      expect(result[0]?.balance).toBeNull();
-      expect(result[0]?.vaultInfo.id).toBe('sUSDC');
-      expect(result[0]?.vaultInfo.metadata?.apy).toBeDefined();
-      expect(typeof result[0]?.vaultInfo.metadata?.apy).toBe('number');
+      expect(result.overall).toEqual({ currentBalance: 0, actualCurrentBalance: 0 });
+      expect(result.perVault).toHaveLength(1);
+      expect(result.perVault[0]?.balance).toBe('0');
+      expect(result.perVault[0]?.vaultInfo.id).toBe('sUSDC');
+      expect(result.perVault[0]?.vaultInfo.metadata?.apy).toBeDefined();
+      expect(typeof result.perVault[0]?.vaultInfo.metadata?.apy).toBe('number');
     });
 
     it('should throw error when public client is not initialized', async () => {

--- a/packages/sdk/src/protocols/implementations/SparkProtocol.ts
+++ b/packages/sdk/src/protocols/implementations/SparkProtocol.ts
@@ -11,7 +11,7 @@ import {
   SPARK_SSR_ORACLE_ADDRESS,
   SPARK_VAULT,
 } from '@/protocols/constants/spark';
-import type { VaultBalance, VaultInfo, Vaults, VaultTxnResult } from '@/types/protocols/general';
+import type { AddressBalance, VaultInfo, Vaults, VaultTxnResult } from '@/types/protocols/general';
 import type { TransactionData } from '@/types/transaction';
 
 /**
@@ -269,7 +269,7 @@ export class SparkProtocol extends BaseProtocol {
    * @param walletAddress Wallet address to check
    * @returns Array of vault balances with vaults info
    */
-  async getBalances(walletAddress: Address): Promise<VaultBalance[]> {
+  async getBalances(walletAddress: Address): Promise<AddressBalance> {
     if (!this.publicClient) {
       throw new Error('Public client not initialized');
     }
@@ -287,7 +287,18 @@ export class SparkProtocol extends BaseProtocol {
     });
 
     if (shares === 0n) {
-      return [{ balance: null, vaultInfo }];
+      return {
+        overall: {
+          currentBalance: 0,
+          actualCurrentBalance: 0,
+        },
+        perVault: [
+          {
+            balance: '0',
+            vaultInfo,
+          },
+        ],
+      };
     }
 
     const assets = await this.publicClient.readContract({
@@ -297,11 +308,21 @@ export class SparkProtocol extends BaseProtocol {
       args: [shares],
     });
 
-    return [
-      {
-        balance: formatUnits(assets, vaultInfo.tokenDecimals),
-        vaultInfo,
+    // So far only one vault is supported in this implementation
+    // Later on more vaults should be processed here and take into account in the final result
+    const vaultBalance = formatUnits(assets, vaultInfo.tokenDecimals);
+
+    return {
+      overall: {
+        currentBalance: Number(vaultBalance),
+        actualCurrentBalance: Number(vaultBalance),
       },
-    ];
+      perVault: [
+        {
+          balance: vaultBalance,
+          vaultInfo,
+        },
+      ],
+    };
   }
 }

--- a/packages/sdk/src/public/types.ts
+++ b/packages/sdk/src/public/types.ts
@@ -1,7 +1,13 @@
 /** @public @category Types */
 export type { ProxyBalance } from '@/types/protocols/proxy';
 export type { TokenBalance } from '@/types/token';
-export type { VaultTxnResult, VaultBalance, Vaults, VaultInfo } from '@/types/protocols/general';
+export type {
+  VaultTxnResult,
+  AddressBalance,
+  VaultBalance,
+  Vaults,
+  VaultInfo,
+} from '@/types/protocols/general';
 export type { SmartWallet } from '@/wallet/base/wallets/SmartWallet';
 export type { WalletNamespace } from '@/wallet/WalletNamespace';
 export type { ProtocolsNamespace } from '@/protocols/ProtocolsNamespace';

--- a/packages/sdk/src/types/protocols/general.ts
+++ b/packages/sdk/src/types/protocols/general.ts
@@ -63,7 +63,7 @@ export interface Vaults {
 
 /**
  * @public
- * The info about current user's balance in a protocol vault
+ * The info about current user's balance for a protocol vault
  * @category Types
  * @remarks
  * The generic type that shows fields that should be present in a protocol vault balance
@@ -73,6 +73,30 @@ export interface VaultBalance {
   balance: string | ProxyBalance | null;
   /** info about a protocol vault where a user deposited funds */
   vaultInfo: VaultInfo;
+}
+
+/**
+ * @public
+ * The info about the overall balance of a user in all protocol vaults where he deposited his funds
+ * @category Types
+ */
+export interface OverallAddressBalance {
+  currentBalance: number;
+  actualCurrentBalance: number;
+  pnl?: number;
+  pnl7d?: number;
+  pnl30d?: number;
+  pnl90d?: number;
+}
+
+/**
+ * @public
+ * The info about the balance of a user in all protocol vaults where he deposited his funds and in each protocol vault separately
+ * @category Types
+ */
+export interface AddressBalance {
+  overall: OverallAddressBalance;
+  perVault: VaultBalance[];
 }
 
 /**

--- a/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.spec.ts
@@ -15,7 +15,7 @@ import { createMockCoinbaseCDP } from '@mycelium-sdk/core/test/mocks/CoinbaseCDP
 import type { CoinbaseCDP } from '@mycelium-sdk/core/tools/CoinbaseCDP';
 import { onRampResponseMock } from '@mycelium-sdk/core/test/mocks/ramp/on-ramp';
 import { offRampResponseMock } from '@mycelium-sdk/core/test/mocks/ramp/off-ramp';
-import type { VaultInfo, VaultBalance } from '@mycelium-sdk/core/types/protocols/general';
+import type { AddressBalance, VaultInfo } from '@mycelium-sdk/core/types/protocols/general';
 import { SPARK_VAULT } from '@mycelium-sdk/core/protocols/constants/spark';
 
 vi.mock('viem/account-abstraction', () => ({
@@ -174,7 +174,7 @@ describe('DefaultSmartWallet integration tests', () => {
       vi.mocked(bundlerClient.sendUserOperation).mockResolvedValue('0xTransactionHash');
       vi.mocked(bundlerClient.waitForUserOperationReceipt).mockResolvedValue({
         receipt: { transactionHash: '0xTransactionHash' },
-      });
+      } as any);
 
       const result = await wallet.send(transactionData, chainId);
 
@@ -270,7 +270,7 @@ describe('DefaultSmartWallet integration tests', () => {
       vi.mocked(bundlerClient.sendUserOperation).mockResolvedValue('0xTransactionHash');
       vi.mocked(bundlerClient.waitForUserOperationReceipt).mockResolvedValue({
         receipt: { transactionHash: '0xTransactionHash' },
-      });
+      } as any);
 
       const result = await wallet.sendBatch(transactionData, chainId);
 
@@ -434,27 +434,30 @@ describe('DefaultSmartWallet integration tests', () => {
         mockCoinbaseCDP,
       );
 
-      const mockBalances: VaultBalance[] = [
-        {
-          vaultInfo: mockVaultInfo,
-          balance: '1000',
-        },
-      ];
+      const mockAddressBalance: AddressBalance = {
+        overall: { currentBalance: 1000, actualCurrentBalance: 1000 },
+        perVault: [
+          {
+            vaultInfo: mockVaultInfo,
+            balance: '1000',
+          },
+        ],
+      };
 
       vi.mocked(mockProtocol.getBalances as ReturnType<typeof vi.fn>).mockResolvedValue(
-        mockBalances,
+        mockAddressBalance,
       );
 
       const result = await wallet.getEarnBalances();
 
       expect(mockProtocol.getBalances).toHaveBeenCalledWith(await wallet.getAddress());
-      expect(result).toEqual(mockBalances);
-      expect(result).toHaveLength(1);
-      expect(result[0]?.vaultInfo).toEqual(mockVaultInfo);
-      expect(result[0]?.balance).toBe('1000');
+      expect(result).toEqual(mockAddressBalance);
+      expect(result.perVault).toHaveLength(1);
+      expect(result.perVault[0]?.vaultInfo).toEqual(mockVaultInfo);
+      expect(result.perVault[0]?.balance).toBe('1000');
     });
 
-    it('should return empty array when no balances found', async () => {
+    it('should return empty perVault when no balances found', async () => {
       const wallet = new DefaultSmartWallet(
         mockOwners,
         mockSigner,
@@ -463,11 +466,19 @@ describe('DefaultSmartWallet integration tests', () => {
         mockCoinbaseCDP,
       );
 
-      vi.mocked(mockProtocol.getBalances as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      const emptyAddressBalance: AddressBalance = {
+        overall: { currentBalance: 0, actualCurrentBalance: 0 },
+        perVault: [],
+      };
+
+      vi.mocked(mockProtocol.getBalances as ReturnType<typeof vi.fn>).mockResolvedValue(
+        emptyAddressBalance,
+      );
 
       const result = await wallet.getEarnBalances();
 
-      expect(result).toEqual([]);
+      expect(result).toEqual(emptyAddressBalance);
+      expect(result.perVault).toHaveLength(0);
     });
   });
 

--- a/packages/sdk/src/wallet/DefaultSmartWallet.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.ts
@@ -216,7 +216,7 @@ export class DefaultSmartWallet extends SmartWallet {
    *
    * @public
    * @category Earn
-   * @returns Vault balance or `null` if nothing deposited
+   * @returns Overall balance of a user and the list of vaults where he deposited his funds. {@link AddressBalance}
    */
   async getEarnBalances(): Promise<AddressBalance> {
     const userAddress = await this.getAddress();

--- a/packages/sdk/src/wallet/DefaultSmartWallet.ts
+++ b/packages/sdk/src/wallet/DefaultSmartWallet.ts
@@ -17,7 +17,7 @@ import type { TokenBalance } from '@/types/token';
 import { type AssetIdentifier, parseAssetAmount, resolveAsset } from '@/utils/assets';
 import { SmartWallet } from '@/wallet/base/wallets/SmartWallet';
 import type { TransactionData } from '@/types/transaction';
-import type { VaultBalance, VaultInfo, VaultTxnResult } from '@/types/protocols/general';
+import type { AddressBalance, VaultInfo, VaultTxnResult } from '@/types/protocols/general';
 import type { CoinbaseCDP } from '@/tools/CoinbaseCDP';
 import type { OffRampUrlResponse, OnRampUrlResponse } from '@/types/ramp';
 import type { BaseProtocol } from '@/protocols/base/BaseProtocol';
@@ -218,7 +218,7 @@ export class DefaultSmartWallet extends SmartWallet {
    * @category Earn
    * @returns Vault balance or `null` if nothing deposited
    */
-  async getEarnBalances(): Promise<VaultBalance[]> {
+  async getEarnBalances(): Promise<AddressBalance> {
     const userAddress = await this.getAddress();
     return this.protocolProvider.getBalances(userAddress);
   }

--- a/packages/sdk/src/wallet/base/wallets/SmartWallet.ts
+++ b/packages/sdk/src/wallet/base/wallets/SmartWallet.ts
@@ -4,7 +4,7 @@ import type { SupportedChainId } from '@/constants/chains';
 import type { TokenBalance } from '@/types/token';
 import type { AssetIdentifier } from '@/utils/assets';
 import type { TransactionData } from '@/types/transaction';
-import type { VaultBalance, VaultInfo, VaultTxnResult } from '@/types/protocols/general';
+import type { AddressBalance, VaultInfo, VaultTxnResult } from '@/types/protocols/general';
 import type { OffRampUrlResponse, OnRampUrlResponse } from '@/types/ramp';
 
 /**
@@ -128,7 +128,7 @@ export abstract class SmartWallet {
    * @category Yield
    * @returns Promise resolving to a {@link VaultBalance} or null if none
    */
-  abstract getEarnBalances(): Promise<VaultBalance[] | null>;
+  abstract getEarnBalances(): Promise<AddressBalance | null>;
 
   /**
    * Withdraws a specific amount of shares from the protocol vault

--- a/packages/sdk/src/wallet/base/wallets/SmartWallet.ts
+++ b/packages/sdk/src/wallet/base/wallets/SmartWallet.ts
@@ -126,9 +126,9 @@ export abstract class SmartWallet {
    *
    * @internal
    * @category Yield
-   * @returns Promise resolving to a {@link VaultBalance} or null if none
+   * @returns Promise resolving to a {@link AddressBalance}
    */
-  abstract getEarnBalances(): Promise<AddressBalance | null>;
+  abstract getEarnBalances(): Promise<AddressBalance>;
 
   /**
    * Withdraws a specific amount of shares from the protocol vault


### PR DESCRIPTION
## What was changed?

- Introduced AddressBalance: balance is now returned as:{ overall: OverallAddressBalance; perVault: VaultBalance[] } instead of VaultBalance[]
- getBalances() (SparkProtocol, ProxyProtocol) now returns AddressBalance (overall totals plus per-vault list)
- getEarnBalances() on the wallet now returns AddressBalance instead of VaultBalance[]
- AddressBalance is exported from the SDK public types

## Why was changed/added?

- Mycelium Cloud started to return a different format of data for the balance
- Callers need both an aggregated view (overall balance) and per-vault breakdown; a single type with overall and perVault supports both without extra requests
- Aligns protocol and wallet APIs and keeps balance shape consistent across the SDK

## How to use the change?

Use the new return type: `result.overall` for aggregated numbers, result.perVault for the list of vault balances (same structure as before, but under perVault)

Example: 
```javascript
const { overall, perVault } = await wallet.getEarnBalances(); 
```
and then use `perVault[0].balance`, `perVault[0].vaultInfo`, etc. Replace any code that treated the result as a plain array (e.g. `result[0]`) with `result.perVault[0]` and use `result.overall` when you need totals